### PR TITLE
Fix: prevent inference timeout on legacy GPUs using CUDA_LAUNCH_BLOCKING

### DIFF
--- a/generative-ai/galileo/04-image-generation/README.md
+++ b/generative-ai/galileo/04-image-generation/README.md
@@ -57,6 +57,15 @@ This notebook performs image generation inference using the Stable Diffusion arc
 ### Step 4: Use a Custom Kernel for Notebooks  
 1. In Jupyter notebooks, select the **aistudio kernel** to ensure compatibility.
 
+
+> ⚠️ **GPU Compatibility Notice**  
+If you are using an older GPU architecture (e.g., **pre-Pascal**, such as **Maxwell or earlier**, like the GTX TITAN X), you may experience CUDA timeout errors during inference or training due to hardware limitations.  
+To ensure stable execution, uncomment the line below at the beginning of your script or notebook to force synchronous CUDA execution:
+
+```python
+os.environ["CUDA_LAUNCH_BLOCKING"] = "1"
+```
+
 ## Usage
 
 ### Step 1:

--- a/generative-ai/galileo/04-image-generation/notebooks/inference.ipynb
+++ b/generative-ai/galileo/04-image-generation/notebooks/inference.ipynb
@@ -54,8 +54,19 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "aab66135",
+   "metadata": {},
+   "source": [
+    "> ⚠️ **Warning**: If your GPU uses an older architecture (e.g., **pre-Pascal**, such as **Maxwell or earlier**), please uncomment the following line to avoid CUDA timeout issues:\n",
+    "```python\n",
+    "os.environ[\"CUDA_LAUNCH_BLOCKING\"] = \"1\"\n",
+    "```\n"
+   ]
+  },
+  {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "id": "21c6c798-cdf9-461b-a3a0-cb766773fa5c",
    "metadata": {},
    "outputs": [
@@ -84,6 +95,8 @@
    "source": [
     "import os\n",
     "import sys\n",
+    "\n",
+    "#os.environ[\"CUDA_LAUNCH_BLOCKING\"] = \"1\"\n",
     "\n",
     "sys.path.append(os.path.abspath(os.path.join(os.getcwd(), \"../..\")))\n",
     "from src.utils import (\n",
@@ -1505,9 +1518,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python [conda env:base] *",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "conda-base-py"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -1519,7 +1532,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.7"
+   "version": "3.12.2"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
##  Summary
This PR adds a GPU compatibility warning to the README, targeting older GPU architectures such as Maxwell (pre-Pascal), which may experience CUDA kernel timeouts.

##  Context
During training and inference with Stable Diffusion 2.1 on legacy GPUs like the GTX TITAN X, we observed timeout errors caused by CUDA kernels exceeding the driver's execution time limits.

##  What was added
- A warning block in the README before the Usage section.
- Instructions to uncomment `os.environ["CUDA_LAUNCH_BLOCKING"] = "1"` for stability on older GPUs.

##  Notes
- This is a documentation-only change and does not affect model logic.
