### PR TITLE
Comment Out Proxy Fields in Config.yaml to Prevent External Issues

### DIFF
--- a/deep-learning/question-answering-with-bert/configs/config.yaml
+++ b/deep-learning/question-answering-with-bert/configs/config.yaml
@@ -7,7 +7,7 @@ model_source: "local"
 # Proxy is used to set the HTTPS_PROXY environment variable when necessary.
 # For example, if you need to access external services from a restricted network,
 # you should specify the proxy in this config.yaml file.
-proxy: "http://web-proxy.austin.hp.com:8080"
+# proxy: "http://web-proxy.austin.hp.com:8080"
 
 # UI Configuration
 ui:

--- a/deep-learning/text-generation-with-rnn/configs/config.yaml
+++ b/deep-learning/text-generation-with-rnn/configs/config.yaml
@@ -7,7 +7,7 @@ model_source: "local"
 # Proxy is used to set the HTTPS_PROXY environment variable when necessary.
 # For example, if you need to access external services from a restricted network,
 # you should specify the proxy in this config.yaml file.
-proxy: "http://web-proxy.austin.hp.com:8080"
+# proxy: "http://web-proxy.austin.hp.com:8080"
 
 # UI Configuration
 ui:

--- a/generative-ai/code-generation-with-langchain/configs/config.yaml
+++ b/generative-ai/code-generation-with-langchain/configs/config.yaml
@@ -7,7 +7,7 @@ model_source: "local"
 # Proxy is used to set the HTTPS_PROXY environment variable when necessary.
 # For example, if you need to access external services from a restricted network,
 # you should specify the proxy in this config.yaml file.
-proxy: "http://web-proxy.austin.hp.com:8080"
+# proxy: "http://web-proxy.austin.hp.com:8080"
 
 # UI Configuration
 ui:

--- a/generative-ai/fine-tuning-with-orpo/configs/config.yaml
+++ b/generative-ai/fine-tuning-with-orpo/configs/config.yaml
@@ -7,7 +7,7 @@ model_source: "local"
 # Proxy is used to set the HTTPS_PROXY environment variable when necessary.
 # For example, if you need to access external services from a restricted network,
 # you should specify the proxy in this config.yaml file.
-proxy: "http://web-proxy.austin.hp.com:8080"
+# proxy: "http://web-proxy.austin.hp.com:8080"
 
 # UI Configuration
 ui:


### PR DESCRIPTION
This PR updates the configuration files for **4 blueprints** to improve compatibility for external customers:

[question-answering-with-bert](https://github.com/HPInc/AI-Blueprints/tree/main/deep-learning/question-answering-with-bert)
[text-generation-with-rnn](https://github.com/HPInc/AI-Blueprints/tree/main/deep-learning/text-generation-with-rnn)
[code-generation-with-langchain](https://github.com/HPInc/AI-Blueprints/tree/main/generative-ai/code-generation-with-langchain)
[fine-tuning-with-orpo](https://github.com/HPInc/AI-Blueprints/tree/main/generative-ai/fine-tuning-with-orpo)


**Key Changes:**

* Commented out proxy fields in `config.yaml` that contained HP proxy addresses.
* Prevents potential connectivity and usability issues when running these blueprints outside internal HP environments.

These changes ensure smoother experience for external users while preserving internal functionality if proxy settings are later required.
