### PR TITLE
Fix: free LLM VRAM in run-workflow

### DIFF
--- a/deep-learning/classification-with-keras/demo/streamlit/main.py
+++ b/deep-learning/classification-with-keras/demo/streamlit/main.py
@@ -6,7 +6,6 @@ from io import BytesIO
 import numpy as np
 from pathlib import Path
 
-
 os.environ.setdefault("NO_PROXY", "localhost,127.0.0.1")
 # --- Streamlit Page Configuration ---
 st.set_page_config(

--- a/deep-learning/question-answering-with-bert/demo/streamlit/main.py
+++ b/deep-learning/question-answering-with-bert/demo/streamlit/main.py
@@ -6,7 +6,6 @@ from io import BytesIO
 import numpy as np
 from pathlib import Path
 
-
 os.environ.setdefault("NO_PROXY", "localhost,127.0.0.1")
 # --- Streamlit Page Configuration ---
 st.set_page_config(

--- a/deep-learning/spam-detection-with-nlp/demo/streamlit/main.py
+++ b/deep-learning/spam-detection-with-nlp/demo/streamlit/main.py
@@ -6,7 +6,6 @@ import base64
 import numpy as np
 from pathlib import Path
 
-
 os.environ.setdefault("NO_PROXY", "localhost,127.0.0.1")
 # --- Streamlit Page Configuration ---
 st.set_page_config(

--- a/deep-learning/text-generation-with-rnn/demo/streamlit/main.py
+++ b/deep-learning/text-generation-with-rnn/demo/streamlit/main.py
@@ -6,7 +6,6 @@ from io import BytesIO
 import numpy as np
 from pathlib import Path
 
-
 os.environ.setdefault("NO_PROXY", "localhost,127.0.0.1")
 # --- Streamlit Page Configuration ---
 st.set_page_config(

--- a/deep-learning/text-generation-with-rnn/src/utils.py
+++ b/deep-learning/text-generation-with-rnn/src/utils.py
@@ -22,7 +22,6 @@ from botocore import UNSIGNED  # Disable request signing
 from botocore.config import Config  # Botocore configuration
 from IPython.display import HTML, display  # Rich HTML display utilities (Jupyter)
 
-
 # Color and emoji mapping per level
 STYLE_MAP = {
     logging.DEBUG: {"bg": "#1e90ff", "fg": "white", "icon": "🔍"},

--- a/generative-ai/agentic-audio-rag-with-langgraph/demo/streamlit/main.py
+++ b/generative-ai/agentic-audio-rag-with-langgraph/demo/streamlit/main.py
@@ -233,8 +233,7 @@ st.markdown(
 # ─────────────────────────────────────────────────────────────
 st.sidebar.title("⚙️ Configuration")
 
-st.sidebar.markdown(
-    """
+st.sidebar.markdown("""
 **How to use:**
 1. Upload an audio or video file
 2. Wait for processing (embedding generation)
@@ -244,8 +243,7 @@ st.sidebar.markdown(
 **Supported Formats:**
 - Audio: MP3, WAV, OGG, FLAC, M4A
 - Video: MP4, MOV, AVI, MKV, WEBM
-"""
-)
+""")
 
 MLFLOW_ENDPOINT = st.sidebar.text_input(
     "MLflow Model Endpoint URL",

--- a/generative-ai/agentic-audio-rag-with-langgraph/src/generate_test_audio.py
+++ b/generative-ai/agentic-audio-rag-with-langgraph/src/generate_test_audio.py
@@ -37,8 +37,7 @@ def generate_meeting_audio(media_path: Path) -> None:
     SAMPLE_BASE.parent.mkdir(parents=True, exist_ok=True)
     MASTER_WAV = SAMPLE_BASE.with_suffix(".wav")
 
-    script = textwrap.dedent(
-        """
+    script = textwrap.dedent("""
         Hello everyone, and welcome to the Project Helios kickoff.
         I'm Alex, the product lead. Also joining: Ben from engineering, Carla from design, and Diego from data.
         Our goal is to ship a private beta by August fifth, focused on the voice search experience.
@@ -67,8 +66,7 @@ def generate_meeting_audio(media_path: Path) -> None:
         Our next review is on Monday at ten A M central.
 
         That’s the plan—ask me anything about this meeting.
-    """
-    ).strip()
+    """).strip()
 
     if not MASTER_WAV.exists():
         engine = pyttsx3.init()

--- a/generative-ai/agentic-feedback-analyzer-with-langgraph/demo/streamlit/main.py
+++ b/generative-ai/agentic-feedback-analyzer-with-langgraph/demo/streamlit/main.py
@@ -46,13 +46,11 @@ st.markdown(
 # ------------------------- SIDEBAR CONFIG -------------------------
 st.sidebar.title("⚙️ Usage")
 
-st.sidebar.markdown(
-    """
+st.sidebar.markdown("""
 **Instructions:**
 1. Fill out the topic, question, and uploaded documents.
 2. Click **Run Analysis** to receive an AI-generated answer about your documents.
-"""
-)
+""")
 
 endpoint_url = "http://localhost:5002/invocations"
 

--- a/generative-ai/agentic-feedback-analyzer-with-langgraph/src/mlflow/model.py
+++ b/generative-ai/agentic-feedback-analyzer-with-langgraph/src/mlflow/model.py
@@ -26,7 +26,6 @@ from pydantic import BaseModel
 from src.agentic_workflow import build_agentic_graph
 from src.simple_kv_memory import SimpleKVMemory
 
-
 # Set up logger
 logger = logging.getLogger(__name__)
 

--- a/generative-ai/agentic-feedback-analyzer-with-langgraph/src/utils.py
+++ b/generative-ai/agentic-feedback-analyzer-with-langgraph/src/utils.py
@@ -13,7 +13,6 @@ from IPython.display import (
     display,
 )  # Rich HTML display utilities for Jupyter environments
 
-
 # Color and emoji mapping per level
 STYLE_MAP = {
     logging.DEBUG: {"bg": "#1e90ff", "fg": "white", "icon": "🔍"},

--- a/generative-ai/agentic-github-repo-analyzer-with-langgraph/demo/streamlit/main.py
+++ b/generative-ai/agentic-github-repo-analyzer-with-langgraph/demo/streamlit/main.py
@@ -48,13 +48,11 @@ st.markdown(
 # ------------------------- SIDEBAR CONFIG -------------------------
 st.sidebar.title("⚙️ Usage")
 
-st.sidebar.markdown(
-    """
+st.sidebar.markdown("""
 **Instructions:**
 1. Fill out the topic, question, repo url, and folder path.
 2. Click **Run Analysis** to receive an AI-generated answer from your analyzed repo.
-"""
-)
+""")
 
 endpoint_url = "http://localhost:5002/invocations"
 

--- a/generative-ai/agentic-github-repo-analyzer-with-langgraph/src/utils.py
+++ b/generative-ai/agentic-github-repo-analyzer-with-langgraph/src/utils.py
@@ -13,7 +13,6 @@ from IPython.display import (
     display,
 )  # Rich HTML display utilities for Jupyter environments
 
-
 # Color and emoji mapping per level
 STYLE_MAP = {
     logging.DEBUG: {"bg": "#1e90ff", "fg": "white", "icon": "🔍"},

--- a/generative-ai/automated-evaluation-with-structured-outputs/demo/streamlit/main.py
+++ b/generative-ai/automated-evaluation-with-structured-outputs/demo/streamlit/main.py
@@ -55,12 +55,10 @@ except Exception as e:
 # ─────────────────────────────────────────────────────────────
 st.title("⚙️📊🦙 Automated Evaluation with Structured Outputs")
 
-st.markdown(
-    """
+st.markdown("""
 Upload a **CSV** (or paste table) containing at least the chosen
 *key column* and *text column*. Adjust the parameters in the sidebar, then press **Evaluate**.
-"""
-)
+""")
 
 uploaded = st.file_uploader("Upload CSV", type=["csv"])
 raw_text = st.text_area("…or paste CSV/TSV content here", height=150)

--- a/generative-ai/automated-evaluation-with-structured-outputs/notebooks/register-model.ipynb
+++ b/generative-ai/automated-evaluation-with-structured-outputs/notebooks/register-model.ipynb
@@ -70,11 +70,21 @@
    "metadata": {},
    "outputs": [
     {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2025-10-14 13:39:09 - INFO - Notebook execution started.\n"
-     ]
+     "data": {
+      "text/html": [
+       "\n",
+       "        <div style=\"background-color: #228B22; color: white;\n",
+       "                    padding: 4px 8px; font-family: monospace; border-radius: 4px;\">\n",
+       "            ✅ 2026-04-06 16:36:09 - INFO - Notebook execution started.\n",
+       "        </div>\n",
+       "        "
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
     }
    ],
    "source": [
@@ -145,8 +155,8 @@
      "output_type": "stream",
      "text": [
       "Note: you may need to restart the kernel to use updated packages.\n",
-      "CPU times: user 16.8 ms, sys: 7.34 ms, total: 24.2 ms\n",
-      "Wall time: 993 ms\n"
+      "CPU times: user 18.4 ms, sys: 2.65 ms, total: 21.1 ms\n",
+      "Wall time: 1.04 s\n"
      ]
     }
    ],
@@ -288,12 +298,38 @@
    "metadata": {},
    "outputs": [
     {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2025-10-14 13:39:11 - INFO - Input Data is properly configured.\n",
-      "2025-10-14 13:39:11 - INFO - LLaMA Local model is properly configured.\n"
-     ]
+     "data": {
+      "text/html": [
+       "\n",
+       "        <div style=\"background-color: #228B22; color: white;\n",
+       "                    padding: 4px 8px; font-family: monospace; border-radius: 4px;\">\n",
+       "            ✅ 2026-04-06 16:36:36 - INFO - Input Data is properly configured.\n",
+       "        </div>\n",
+       "        "
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "        <div style=\"background-color: #228B22; color: white;\n",
+       "                    padding: 4px 8px; font-family: monospace; border-radius: 4px;\">\n",
+       "            ✅ 2026-04-06 16:36:36 - INFO - LLaMA Local model is properly configured.\n",
+       "        </div>\n",
+       "        "
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
     }
    ],
    "source": [
@@ -465,8 +501,8 @@
        "    </tr>\n",
        "    <tr>\n",
        "      <th>9</th>\n",
-       "      <td>A Novel Mathematical Simulation to Study the D...</td>\n",
-       "      <td>Materials Science</td>\n",
+       "      <td>A Novel Approach to Solar Desalination Using N...</td>\n",
+       "      <td>Plant Sciences</td>\n",
        "      <td>2014</td>\n",
        "      <td>set()</td>\n",
        "      <td>The purpose of the project was to determine if...</td>\n",
@@ -502,7 +538,7 @@
        "6                  Embedded Systems  2014   set()   \n",
        "7                      Microbiology  2014   set()   \n",
        "8                    Plant Sciences  2014   set()   \n",
-       "9                 Materials Science  2014   set()   \n",
+       "9                    Plant Sciences  2014   set()   \n",
        "\n",
        "                                            abstract  \\\n",
        "0  Purpose: A human neck replica was made to simu...   \n",
@@ -526,7 +562,7 @@
        "6  United States of America    MO       NaN                     ['nan']  \n",
        "7  United States of America    HI       NaN   ['Third Award of $1,000']  \n",
        "8  United States of America    TX       NaN  ['Second Award of $2,000']  \n",
-       "9  United States of America    TX       NaN                     ['nan']  "
+       "9  United States of America    FL       NaN                     ['nan']  "
       ]
      },
      "execution_count": 10,
@@ -573,13 +609,55 @@
    "metadata": {},
    "outputs": [
     {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2025-10-14 13:39:11 - INFO - Using model path: /home/jovyan/datafabric/meta-llama3.1-8b-Q8/Meta-Llama-3.1-8B-Instruct-Q8_0.gguf\n",
-      "2025-10-14 13:39:11 - INFO - Configuration loaded from: ../configs/config.yaml\n",
-      "2025-10-14 13:39:11 - INFO - Model registration will use Logger.log_model()\n"
-     ]
+     "data": {
+      "text/html": [
+       "\n",
+       "        <div style=\"background-color: #228B22; color: white;\n",
+       "                    padding: 4px 8px; font-family: monospace; border-radius: 4px;\">\n",
+       "            ✅ 2026-04-06 16:36:42 - INFO - Using model path: /home/jovyan/datafabric/meta-llama3.1-8b-Q8/Meta-Llama-3.1-8B-Instruct-Q8_0.gguf\n",
+       "        </div>\n",
+       "        "
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "        <div style=\"background-color: #228B22; color: white;\n",
+       "                    padding: 4px 8px; font-family: monospace; border-radius: 4px;\">\n",
+       "            ✅ 2026-04-06 16:36:42 - INFO - Configuration loaded from: ../configs/config.yaml\n",
+       "        </div>\n",
+       "        "
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "        <div style=\"background-color: #228B22; color: white;\n",
+       "                    padding: 4px 8px; font-family: monospace; border-radius: 4px;\">\n",
+       "            ✅ 2026-04-06 16:36:42 - INFO - Model registration will use Logger.log_model()\n",
+       "        </div>\n",
+       "        "
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
     }
    ],
    "source": [
@@ -605,7 +683,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 13,
    "id": "53a7ea0a-d48c-4ea7-b050-1127851ae7c7",
    "metadata": {},
    "outputs": [
@@ -613,13 +691,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2025/10/14 13:39:11 INFO mlflow.tracking.fluent: Experiment with name 'EvaluationExperiment' does not exist. Creating a new experiment.\n",
-      "2025-10-14 13:39:11 - INFO - Run ID: c968c11303fb437f969780b73296fe17\n",
-      "2025/10/14 13:40:19 WARNING mlflow.models.model: `artifact_path` is deprecated. Please use `name` instead.\n",
-      "Successfully registered model 'EvaluationModel'.\n",
-      "2025/10/14 13:41:35 WARNING mlflow.tracking._model_registry.fluent: Run with id c968c11303fb437f969780b73296fe17 has no artifacts at artifact path 'EvaluationModel', registering model based on models:/m-caad6cd2d3034ecd9b71a1ad7c0006c7 instead\n",
-      "Created version '1' of model 'EvaluationModel'.\n",
-      "2025-10-14 13:41:36 - INFO - Registered model: EvaluationModel\n"
+      "2026/04/06 16:36:47 INFO mlflow.tracking.fluent: Experiment with name 'EvaluationExperiment' does not exist. Creating a new experiment.\n"
      ]
     },
     {
@@ -628,7 +700,7 @@
        "\n",
        "        <div style=\"background-color: #228B22; color: white;\n",
        "                    padding: 4px 8px; font-family: monospace; border-radius: 4px;\">\n",
-       "            ✅ 2025-09-29 19:27:11 - INFO - Model 'EvaluationModel' logged and registered.\n",
+       "            ✅ 2026-04-06 16:36:47 - INFO - Run ID: fea07bfdfd544fbfbcda35d6e6af93ee\n",
        "        </div>\n",
        "        "
       ],
@@ -640,12 +712,22 @@
      "output_type": "display_data"
     },
     {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026/04/06 16:37:58 WARNING mlflow.models.model: `artifact_path` is deprecated. Please use `name` instead.\n",
+      "Successfully registered model 'EvaluationModel'.\n",
+      "2026/04/06 16:39:25 WARNING mlflow.tracking._model_registry.fluent: Run with id fea07bfdfd544fbfbcda35d6e6af93ee has no artifacts at artifact path 'EvaluationModel', registering model based on models:/m-e93dd9ba2ce742b4abafc73703b31c59 instead\n",
+      "Created version '1' of model 'EvaluationModel'.\n"
+     ]
+    },
+    {
      "data": {
       "text/html": [
        "\n",
        "        <div style=\"background-color: #228B22; color: white;\n",
        "                    padding: 4px 8px; font-family: monospace; border-radius: 4px;\">\n",
-       "            ✅ 2025-09-29 19:27:11 - INFO - Registered model: EvaluationModel\n",
+       "            ✅ 2026-04-06 16:39:25 - INFO - Registered model: EvaluationModel\n",
        "        </div>\n",
        "        "
       ],
@@ -660,8 +742,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 620 ms, sys: 34.6 s, total: 35.2 s\n",
-      "Wall time: 2min 24s\n"
+      "CPU times: user 2.14 s, sys: 45.2 s, total: 47.3 s\n",
+      "Wall time: 2min 38s\n"
      ]
     }
    ],
@@ -729,11 +811,21 @@
    "metadata": {},
    "outputs": [
     {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2025-10-14 13:41:36 - INFO - Latest model version: 1\n"
-     ]
+     "data": {
+      "text/html": [
+       "\n",
+       "        <div style=\"background-color: #228B22; color: white;\n",
+       "                    padding: 4px 8px; font-family: monospace; border-radius: 4px;\">\n",
+       "            ✅ 2026-04-06 16:39:59 - INFO - Latest model version: 1\n",
+       "        </div>\n",
+       "        "
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
     }
    ],
    "source": [
@@ -758,11 +850,18 @@
    "metadata": {},
    "outputs": [
     {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "llama_context: n_ctx_per_seq (8192) < n_ctx_train (131072) -- the full capacity of the model will not be utilized\n"
+     ]
+    },
+    {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 900 ms, sys: 3.21 s, total: 4.11 s\n",
-      "Wall time: 45.7 s\n"
+      "CPU times: user 2.14 s, sys: 1.81 s, total: 3.95 s\n",
+      "Wall time: 46.8 s\n"
      ]
     }
    ],
@@ -775,7 +874,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 16,
    "id": "adb29ecd-b249-48d9-96a4-4b90d7060c72",
    "metadata": {
     "scrolled": true
@@ -785,19 +884,67 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2025/10/14 13:42:22 WARNING mlflow.models.utils: Found extra inputs in the model input that are not defined in the model signature: `['year', 'country', 'State', 'schools', 'Province', 'awards', 'category']`. These inputs will be ignored.\n",
-      "2025/10/14 13:42:22 WARNING mlflow.models.utils: `params` can only be specified at inference time if the model signature defines a params schema. This model does not define a params schema. Ignoring provided params: ['key_column', 'eval_column', 'criteria']\n",
-      "2025-10-14 13:42:25 - INFO - Sample inference completed successfully\n",
-      "2025-10-14 13:42:25 - INFO - Prediction result shape: (1, 9)\n",
-      "2025-10-14 13:42:25 - INFO - Prediction columns: ['title', 'abstract', 'Originality', 'ScientificRigor', 'Clarity', 'Relevance', 'Feasibility', 'Brevity', 'TotalScore']\n"
+      "2026/04/06 16:40:54 WARNING mlflow.models.utils: Found extra inputs in the model input that are not defined in the model signature: `['schools', 'year', 'category', 'country', 'Province', 'awards', 'State']`. These inputs will be ignored.\n",
+      "2026/04/06 16:40:54 WARNING mlflow.models.utils: `params` can only be specified at inference time if the model signature defines a params schema. This model does not define a params schema. Ignoring provided params: ['key_column', 'eval_column', 'criteria']\n"
      ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "        <div style=\"background-color: #228B22; color: white;\n",
+       "                    padding: 4px 8px; font-family: monospace; border-radius: 4px;\">\n",
+       "            ✅ 2026-04-06 18:03:28 - INFO - Sample inference completed successfully\n",
+       "        </div>\n",
+       "        "
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "        <div style=\"background-color: #228B22; color: white;\n",
+       "                    padding: 4px 8px; font-family: monospace; border-radius: 4px;\">\n",
+       "            ✅ 2026-04-06 18:03:28 - INFO - Prediction result shape: (8, 9)\n",
+       "        </div>\n",
+       "        "
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "        <div style=\"background-color: #228B22; color: white;\n",
+       "                    padding: 4px 8px; font-family: monospace; border-radius: 4px;\">\n",
+       "            ✅ 2026-04-06 18:03:28 - INFO - Prediction columns: ['title', 'abstract', 'Originality', 'ScientificRigor', 'Clarity', 'Relevance', 'Feasibility', 'Brevity', 'TotalScore']\n",
+       "        </div>\n",
+       "        "
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 3.18 s, sys: 205 ms, total: 3.38 s\n",
-      "Wall time: 3.4 s\n"
+      "CPU times: user 1h 2min 10s, sys: 20min 25s, total: 1h 22min 36s\n",
+      "Wall time: 1h 22min 34s\n"
      ]
     }
    ],
@@ -840,13 +987,55 @@
    "metadata": {},
    "outputs": [
     {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2025-10-14 13:42:25 - INFO - Using prediction results directly (already contains TotalScore)\n",
-      "2025-10-14 13:42:25 - INFO - Final results shape: (1, 9)\n",
-      "2025-10-14 13:42:25 - INFO - Final columns: ['title', 'abstract', 'Originality', 'ScientificRigor', 'Clarity', 'Relevance', 'Feasibility', 'Brevity', 'TotalScore']\n"
-     ]
+     "data": {
+      "text/html": [
+       "\n",
+       "        <div style=\"background-color: #228B22; color: white;\n",
+       "                    padding: 4px 8px; font-family: monospace; border-radius: 4px;\">\n",
+       "            ✅ 2026-04-06 18:05:49 - INFO - Using prediction results directly (already contains TotalScore)\n",
+       "        </div>\n",
+       "        "
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "        <div style=\"background-color: #228B22; color: white;\n",
+       "                    padding: 4px 8px; font-family: monospace; border-radius: 4px;\">\n",
+       "            ✅ 2026-04-06 18:05:49 - INFO - Final results shape: (8, 9)\n",
+       "        </div>\n",
+       "        "
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "        <div style=\"background-color: #228B22; color: white;\n",
+       "                    padding: 4px 8px; font-family: monospace; border-radius: 4px;\">\n",
+       "            ✅ 2026-04-06 18:05:49 - INFO - Final columns: ['title', 'abstract', 'Originality', 'ScientificRigor', 'Clarity', 'Relevance', 'Feasibility', 'Brevity', 'TotalScore']\n",
+       "        </div>\n",
+       "        "
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
     },
     {
      "data": {
@@ -885,70 +1074,97 @@
        "      <th>0</th>\n",
        "      <td>Dynamic Response of a Human Neck Replica to Ax...</td>\n",
        "      <td>Purpose: A human neck replica was made to simu...</td>\n",
-       "      <td>0</td>\n",
+       "      <td>3</td>\n",
        "      <td>4</td>\n",
        "      <td>2</td>\n",
-       "      <td>0</td>\n",
-       "      <td>3</td>\n",
        "      <td>1</td>\n",
-       "      <td>10</td>\n",
+       "      <td>2</td>\n",
+       "      <td>1</td>\n",
+       "      <td>13</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>The Effect of Nutrient Solution Concentration ...</td>\n",
+       "      <td>Studies comparing the mineral nutrition of hyd...</td>\n",
+       "      <td>2</td>\n",
+       "      <td>3</td>\n",
+       "      <td>2</td>\n",
+       "      <td>1</td>\n",
+       "      <td>2</td>\n",
+       "      <td>2</td>\n",
+       "      <td>12</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>Insect-repelling Plants &amp; New Organic Pesticide</td>\n",
+       "      <td>Organochlorine pesticides in agriculture are n...</td>\n",
+       "      <td>1</td>\n",
+       "      <td>2</td>\n",
+       "      <td>2</td>\n",
+       "      <td>1</td>\n",
+       "      <td>2</td>\n",
+       "      <td>1</td>\n",
+       "      <td>9</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>5</th>\n",
+       "      <td>Dye Sensitized Solar Cells: New Structures and...</td>\n",
+       "      <td>Although fossil fuels have the capacity to pow...</td>\n",
+       "      <td>2</td>\n",
+       "      <td>3</td>\n",
+       "      <td>0</td>\n",
+       "      <td>1</td>\n",
+       "      <td>2</td>\n",
+       "      <td>1</td>\n",
+       "      <td>9</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>7</th>\n",
+       "      <td>A Novel Approach to Solar Desalination Using N...</td>\n",
+       "      <td>The purpose of the project was to determine if...</td>\n",
+       "      <td>2</td>\n",
+       "      <td>3</td>\n",
+       "      <td>0</td>\n",
+       "      <td>1</td>\n",
+       "      <td>2</td>\n",
+       "      <td>1</td>\n",
+       "      <td>9</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>6</th>\n",
+       "      <td>A Novel Method for Determination of Camera Pos...</td>\n",
+       "      <td>The method proposed here solves for the pose o...</td>\n",
+       "      <td>2</td>\n",
+       "      <td>2</td>\n",
+       "      <td>1</td>\n",
+       "      <td>1</td>\n",
+       "      <td>2</td>\n",
+       "      <td>1</td>\n",
+       "      <td>9</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>2</th>\n",
        "      <td>Do Air Root Pruning Pots Accelerate Success in...</td>\n",
-       "      <td>Physics and Astronomy</td>\n",
-       "      <td>2014</td>\n",
-       "      <td>set()</td>\n",
        "      <td>The purpose of my project was to determine whi...</td>\n",
-       "      <td>United States of America</td>\n",
-       "      <td>LA</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>['nan']</td>\n",
        "      <td>1</td>\n",
        "      <td>2</td>\n",
        "      <td>1</td>\n",
-       "      <td>0</td>\n",
-       "      <td>2</td>\n",
+       "      <td>1</td>\n",
+       "      <td>1</td>\n",
        "      <td>1</td>\n",
        "      <td>7</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>7</th>\n",
-       "      <td>Observational Detection of Solar g-mode Oscill...</td>\n",
-       "      <td>Microbiology</td>\n",
-       "      <td>2014</td>\n",
-       "      <td>set()</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>United States of America</td>\n",
-       "      <td>HI</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>['Third Award of $1,000']</td>\n",
+       "      <th>4</th>\n",
+       "      <td>How Do Different Factors Affect the Accuracy o...</td>\n",
+       "      <td>The purpose of this experiment is to determine...</td>\n",
+       "      <td>2</td>\n",
        "      <td>0</td>\n",
-       "      <td>0</td>\n",
-       "      <td>0</td>\n",
-       "      <td>0</td>\n",
-       "      <td>0</td>\n",
-       "      <td>0</td>\n",
-       "      <td>0</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>8</th>\n",
-       "      <td>Synthesis of Periodic Mesoporous Organosilicas...</td>\n",
-       "      <td>Plant Sciences</td>\n",
-       "      <td>2014</td>\n",
-       "      <td>set()</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>United States of America</td>\n",
-       "      <td>TX</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>['Second Award of $2,000']</td>\n",
-       "      <td>0</td>\n",
-       "      <td>0</td>\n",
-       "      <td>0</td>\n",
-       "      <td>0</td>\n",
-       "      <td>0</td>\n",
-       "      <td>0</td>\n",
-       "      <td>0</td>\n",
+       "      <td>1</td>\n",
+       "      <td>1</td>\n",
+       "      <td>2</td>\n",
+       "      <td>1</td>\n",
+       "      <td>7</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
@@ -957,12 +1173,33 @@
       "text/plain": [
        "                                               title  \\\n",
        "0  Dynamic Response of a Human Neck Replica to Ax...   \n",
+       "1  The Effect of Nutrient Solution Concentration ...   \n",
+       "3    Insect-repelling Plants & New Organic Pesticide   \n",
+       "5  Dye Sensitized Solar Cells: New Structures and...   \n",
+       "7  A Novel Approach to Solar Desalination Using N...   \n",
+       "6  A Novel Method for Determination of Camera Pos...   \n",
+       "2  Do Air Root Pruning Pots Accelerate Success in...   \n",
+       "4  How Do Different Factors Affect the Accuracy o...   \n",
        "\n",
        "                                            abstract  Originality  \\\n",
-       "0  Purpose: A human neck replica was made to simu...            0   \n",
+       "0  Purpose: A human neck replica was made to simu...            3   \n",
+       "1  Studies comparing the mineral nutrition of hyd...            2   \n",
+       "3  Organochlorine pesticides in agriculture are n...            1   \n",
+       "5  Although fossil fuels have the capacity to pow...            2   \n",
+       "7  The purpose of the project was to determine if...            2   \n",
+       "6  The method proposed here solves for the pose o...            2   \n",
+       "2  The purpose of my project was to determine whi...            1   \n",
+       "4  The purpose of this experiment is to determine...            2   \n",
        "\n",
        "   ScientificRigor  Clarity  Relevance  Feasibility  Brevity  TotalScore  \n",
-       "0                4        2          0            3        1          10  "
+       "0                4        2          1            2        1          13  \n",
+       "1                3        2          1            2        2          12  \n",
+       "3                2        2          1            2        1           9  \n",
+       "5                3        0          1            2        1           9  \n",
+       "7                3        0          1            2        1           9  \n",
+       "6                2        1          1            2        1           9  \n",
+       "2                2        1          1            1        1           7  \n",
+       "4                0        1          1            2        1           7  "
       ]
      },
      "execution_count": 17,
@@ -1020,11 +1257,21 @@
    "metadata": {},
    "outputs": [
     {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2025-10-14 13:42:25 - INFO - ✅ Evaluation results successfully saved to: ../data/outputs/Evaluated - 2025 ISEF Project Abstracts.csv - 2025-10-14 13-39-09\n"
-     ]
+     "data": {
+      "text/html": [
+       "\n",
+       "        <div style=\"background-color: #228B22; color: white;\n",
+       "                    padding: 4px 8px; font-family: monospace; border-radius: 4px;\">\n",
+       "            ✅ 2026-04-06 18:05:51 - INFO - ✅ Evaluation results successfully saved to: ../data/outputs/Evaluated - 2025 ISEF Project Abstracts.csv - 2026-04-06 16-36-11.csv\n",
+       "        </div>\n",
+       "        "
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
     }
    ],
    "source": [
@@ -1039,12 +1286,38 @@
    "metadata": {},
    "outputs": [
     {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2025-10-14 13:42:25 - INFO - ⏱️ Total execution time: 3m 16.11s\n",
-      "2025-10-14 13:42:25 - INFO - ✅ Notebook execution completed successfully.\n"
-     ]
+     "data": {
+      "text/html": [
+       "\n",
+       "        <div style=\"background-color: #228B22; color: white;\n",
+       "                    padding: 4px 8px; font-family: monospace; border-radius: 4px;\">\n",
+       "            ✅ 2026-04-06 18:05:52 - INFO - ⏱️ Total execution time: 89m 42.86s\n",
+       "        </div>\n",
+       "        "
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "        <div style=\"background-color: #228B22; color: white;\n",
+       "                    padding: 4px 8px; font-family: monospace; border-radius: 4px;\">\n",
+       "            ✅ 2026-04-06 18:05:52 - INFO - ✅ Notebook execution completed successfully.\n",
+       "        </div>\n",
+       "        "
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
     }
    ],
    "source": [

--- a/generative-ai/automated-evaluation-with-structured-outputs/notebooks/run-workflow.ipynb
+++ b/generative-ai/automated-evaluation-with-structured-outputs/notebooks/run-workflow.ipynb
@@ -1,804 +1,1216 @@
 {
-   "cells": [
-      {
-         "cell_type": "markdown",
-         "id": "66cd861d-17bd-49a7-bfcc-01bf5ba3aba6",
-         "metadata": {},
-         "source": [
-            "<h1 style=\\\"text-align: center; font-size: 50px;\\\"> Run Workflow </h1>"
-         ]
-      },
-      {
-         "cell_type": "markdown",
-         "id": "0a095647-8f3b-412f-a249-71f34dbbdd08",
-         "metadata": {},
-         "source": [
-            "# Notebook Overview\n",
-            "\n",
-            "- Start Execution\n",
-            "- Define User Constants\n",
-            "- Install and Import Libraries\n",
-            "- Configure Settings\n",
-            "- Verify Assets\n",
-            "- Load and Validate Data\n",
-            "- Load and Configure the LLM\n",
-            "- Define Helper Functions\n",
-            "- Run Evaluation\n",
-            "- Display Evaluation Results\n",
-            "- Save Evaluation Results"
-         ]
-      },
-      {
-         "cell_type": "markdown",
-         "id": "a5b811b4-c330-482b-af25-b23cb8183a68",
-         "metadata": {},
-         "source": [
-            "# Start Execution"
-         ]
-      },
-      {
-         "cell_type": "code",
-         "execution_count": 1,
-         "id": "af1d5c21-f2db-4cbe-9695-e835c49b4dc8",
-         "metadata": {},
-         "outputs": [],
-         "source": [
-            "# -----------------------------\n",
-            "# Standard library imports\n",
-            "# -----------------------------\n",
-            "import os                   # Operating system utilities (paths, env vars, etc.)\n",
-            "import sys                  # Python runtime environment manipulation\n",
-            "import time                 # Time-related utilities\n",
-            "from datetime import datetime  # Date and time handling\n",
-            "from pathlib import Path     # Object-oriented filesystem paths\n",
-            "\n",
-            "# -----------------------------\n",
-            "# Local imports\n",
-            "# -----------------------------\n",
-            "# Extend sys.path to allow importing from parent directory\n",
-            "sys.path.append(os.path.abspath(os.path.join(os.getcwd(), \"..\")))\n",
-            "\n",
-            "from src.utils import logger  # Project-specific logging utility"
-         ]
-      },
-      {
-         "cell_type": "code",
-         "execution_count": 2,
-         "id": "7000405f-24cb-4ea0-bb5c-6ba3425343df",
-         "metadata": {},
-         "outputs": [
-            {
-               "name": "stderr",
-               "output_type": "stream",
-               "text": [
-                  "2025-10-14 13:35:58 - INFO - Notebook execution started.\n"
-               ]
-            }
-         ],
-         "source": [
-            "start_time = time.time()  \n",
-            "logger.info(\"Notebook execution started.\")"
-         ]
-      },
-      {
-         "cell_type": "markdown",
-         "id": "87a7247b-8643-4efe-b4bc-1a4e9bd4493b",
-         "metadata": {},
-         "source": [
-            "# Define User Constants"
-         ]
-      },
-      {
-         "cell_type": "code",
-         "execution_count": 3,
-         "id": "4b2bdc9e-8314-42b3-aaf3-c7c036c8f1b0",
-         "metadata": {},
-         "outputs": [],
-         "source": [
-            "# File configuration\n",
-            "INPUT_FILE_NAME: str = \"2025 ISEF Project Abstracts.csv\"\n",
-            "INPUT_DIR: Path = Path(\"../data/inputs\")\n",
-            "OUTPUT_DIR: Path = Path(\"../data/outputs\")\n",
-            "\n",
-            "# Ensure directories exist\n",
-            "INPUT_DIR.mkdir(parents=True, exist_ok=True)\n",
-            "OUTPUT_DIR.mkdir(parents=True, exist_ok=True)\n",
-            "\n",
-            "INPUT_PATH: Path = INPUT_DIR / INPUT_FILE_NAME\n",
-            "TIMESTAMP: str = datetime.now().strftime('%Y-%m-%d %H-%M-%S')\n",
-            "OUTPUT_FILE_NAME: str = f\"Evaluated - {INPUT_FILE_NAME} - {TIMESTAMP}.csv\"\n",
-            "OUTPUT_PATH: Path = OUTPUT_DIR / OUTPUT_FILE_NAME\n",
-            "\n",
-            "LLAMA_MODEL_PATH = \"/home/jovyan/datafabric/meta-llama3.1-8b-Q8/Meta-Llama-3.1-8B-Instruct-Q8_0.gguf\"\n",
-            "\n",
-            "# Evaluation configuration\n",
-            "KEY_COLUMN: str = \"title\"\n",
-            "EVAL_COLUMN: str = \"abstract\"\n",
-            "CRITERIA: dict[str, int] = {\n",
-            "    \"Originality\": 3,\n",
-            "    \"ScientificRigor\": 4,\n",
-            "    \"Clarity\": 2,\n",
-            "    \"Relevance\": 1,\n",
-            "    \"Feasibility\": 3,\n",
-            "    \"Brevity\": 2,\n",
-            "}"
-         ]
-      },
-      {
-         "cell_type": "markdown",
-         "id": "2d705e35-8e1d-4e94-80b5-ea276c8a5662",
-         "metadata": {},
-         "source": [
-            "# Install and Import Libraries"
-         ]
-      },
-      {
-         "cell_type": "code",
-         "execution_count": 4,
-         "id": "23ab0175-d6b0-4ffc-8026-dd0de3813310",
-         "metadata": {},
-         "outputs": [
-            {
-               "name": "stdout",
-               "output_type": "stream",
-               "text": [
-                  "Note: you may need to restart the kernel to use updated packages.\n",
-                  "CPU times: user 47.2 ms, sys: 26.1 ms, total: 73.3 ms\n",
-                  "Wall time: 5.73 s\n"
-               ]
-            }
-         ],
-         "source": [
-            "%%time\n",
-            "\n",
-            "%pip install -r ../requirements.txt --quiet"
-         ]
-      },
-      {
-         "cell_type": "code",
-         "execution_count": 5,
-         "id": "734b268e-3e02-4d07-9104-139e1f75e608",
-         "metadata": {},
-         "outputs": [],
-         "source": [
-            "# -----------------------------\n",
-            "# Standard library imports\n",
-            "# -----------------------------\n",
-            "import multiprocessing  # Provides process-based parallelism\n",
-            "import os               # Interacts with the operating system (paths, env vars, files)\n",
-            "import re               # Regular expression matching and text processing\n",
-            "import sys              # Access to interpreter variables and system functions\n",
-            "import warnings         # Control and display of warning messages\n",
-            "from typing import Any, Dict, List  # Type hints for annotations\n",
-            "\n",
-            "import pandas as pd\n",
-            "from tqdm.auto import tqdm\n",
-            "from llama_cpp import Llama\n",
-            "\n",
-            "sys.path.append(os.path.abspath(os.path.join(os.getcwd(), \"..\")))\n",
-            "\n",
-            "# === Project-Specific Imports (from src.utils) ===\n",
-            "from src.utils import load_config, configure_proxy"
-         ]
-      },
-      {
-         "cell_type": "markdown",
-         "id": "a139ab4f-84d5-4aed-b34c-550fc32c6e16",
-         "metadata": {},
-         "source": [
-            "# Configure Settings"
-         ]
-      },
-      {
-         "cell_type": "code",
-         "execution_count": 6,
-         "id": "1335264b-de7c-41d9-8104-15e7f16ab4c6",
-         "metadata": {},
-         "outputs": [],
-         "source": [
-            "warnings.filterwarnings(\"ignore\")"
-         ]
-      },
-      {
-         "cell_type": "code",
-         "execution_count": 7,
-         "id": "5b52b18f-9065-4376-ab35-2e7caf485203",
-         "metadata": {},
-         "outputs": [
-            {
-               "name": "stdout",
-               "output_type": "stream",
-               "text": [
-                  "✅ Configuration loaded successfully\n"
-               ]
-            }
-         ],
-         "source": [
-            "# Load configuration\n",
-            "CONFIG_PATH = \"../configs/config.yaml\"\n",
-            "config = load_config(CONFIG_PATH)\n",
-            "\n",
-            "model_path = config.get(\"model_path\")\n",
-            "\n",
-            "# Configure proxy if specified\n",
-            "configure_proxy(config)\n",
-            "\n",
-            "print(\"✅ Configuration loaded successfully\")"
-         ]
-      },
-      {
-         "cell_type": "markdown",
-         "id": "316487ad-0590-4963-aa17-5d2d1d6eb6c8",
-         "metadata": {},
-         "source": [
-            "# Verify Assets"
-         ]
-      },
-      {
-         "cell_type": "code",
-         "execution_count": 7,
-         "id": "2fff1675-6400-440b-8a96-7bd1ae098558",
-         "metadata": {},
-         "outputs": [],
-         "source": [
-            "def log_asset_status(asset_path: str, asset_name: str) -> None:\n",
-            "    \"\"\"\n",
-            "    Logs the status of a given asset based on its existence.\n",
-            "\n",
-            "    Parameters:\n",
-            "        asset_path (str): File or directory path to check.\n",
-            "        asset_name (str): Name of the asset for logging context.\n",
-            "    \"\"\"\n",
-            "    if Path(asset_path).exists():\n",
-            "        logger.info(f\"{asset_name} is properly configured.\")\n",
-            "    else:\n",
-            "        logger.info(f\"{asset_name} is not properly configured. Please ensure the required asset is correctly configured in your AI Studio project according to the README file.\")"
-         ]
-      },
-      {
-         "cell_type": "code",
-         "execution_count": 8,
-         "id": "375e6d07-77eb-4047-8137-94999f7bf863",
-         "metadata": {},
-         "outputs": [
-            {
-               "name": "stderr",
-               "output_type": "stream",
-               "text": [
-                  "2025-10-14 13:36:04 - INFO - Input Data is properly configured.\n",
-                  "2025-10-14 13:36:04 - INFO - LLaMA Local model is properly configured.\n"
-               ]
-            }
-         ],
-         "source": [
-            "log_asset_status(\n",
-            "    asset_path=INPUT_PATH,\n",
-            "    asset_name=\"Input Data\",\n",
-            ")\n",
-            "\n",
-            "log_asset_status(\n",
-            "    asset_path=model_path,\n",
-            "    asset_name=\"LLaMA Local model\",\n",
-            ")"
-         ]
-      },
-      {
-         "cell_type": "markdown",
-         "id": "66303ae6-4cb7-4417-a3eb-c4208e75a8e5",
-         "metadata": {},
-         "source": [
-            "# Load and Validate Data"
-         ]
-      },
-      {
-         "cell_type": "code",
-         "execution_count": 9,
-         "id": "fed09dd6-0fbb-4dc5-b181-6bb41bb60ba0",
-         "metadata": {},
-         "outputs": [
-            {
-               "data": {
-                  "text/html": [
-                     "<div>\n",
-                     "<style scoped>\n",
-                     "    .dataframe tbody tr th:only-of-type {\n",
-                     "        vertical-align: middle;\n",
-                     "    }\n",
-                     "\n",
-                     "    .dataframe tbody tr th {\n",
-                     "        vertical-align: top;\n",
-                     "    }\n",
-                     "\n",
-                     "    .dataframe thead th {\n",
-                     "        text-align: right;\n",
-                     "    }\n",
-                     "</style>\n",
-                     "<table border=\"1\" class=\"dataframe\">\n",
-                     "  <thead>\n",
-                     "    <tr style=\"text-align: right;\">\n",
-                     "      <th></th>\n",
-                     "      <th>title</th>\n",
-                     "      <th>category</th>\n",
-                     "      <th>year</th>\n",
-                     "      <th>schools</th>\n",
-                     "      <th>abstract</th>\n",
-                     "      <th>country</th>\n",
-                     "      <th>State</th>\n",
-                     "      <th>Province</th>\n",
-                     "      <th>awards</th>\n",
-                     "    </tr>\n",
-                     "  </thead>\n",
-                     "  <tbody>\n",
-                     "    <tr>\n",
-                     "      <th>0</th>\n",
-                     "      <td>Dynamic Response of a Human Neck Replica to Ax...</td>\n",
-                     "      <td>Energy: Physical</td>\n",
-                     "      <td>2014</td>\n",
-                     "      <td>set()</td>\n",
-                     "      <td>Purpose: A human neck replica was made to simu...</td>\n",
-                     "      <td>United States of America</td>\n",
-                     "      <td>MN</td>\n",
-                     "      <td>NaN</td>\n",
-                     "      <td>['nan']</td>\n",
-                     "    </tr>\n",
-                     "    <tr>\n",
-                     "      <th>1</th>\n",
-                     "      <td>The Effect of Nutrient Solution Concentration ...</td>\n",
-                     "      <td>Physics and Astronomy</td>\n",
-                     "      <td>2014</td>\n",
-                     "      <td>set()</td>\n",
-                     "      <td>Studies comparing the mineral nutrition of hyd...</td>\n",
-                     "      <td>United States of America</td>\n",
-                     "      <td>UT</td>\n",
-                     "      <td>NaN</td>\n",
-                     "      <td>['nan']</td>\n",
-                     "    </tr>\n",
-                     "    <tr>\n",
-                     "      <th>2</th>\n",
-                     "      <td>Do Air Root Pruning Pots Accelerate Success in...</td>\n",
-                     "      <td>Physics and Astronomy</td>\n",
-                     "      <td>2014</td>\n",
-                     "      <td>set()</td>\n",
-                     "      <td>The purpose of my project was to determine whi...</td>\n",
-                     "      <td>United States of America</td>\n",
-                     "      <td>LA</td>\n",
-                     "      <td>NaN</td>\n",
-                     "      <td>['nan']</td>\n",
-                     "    </tr>\n",
-                     "    <tr>\n",
-                     "      <th>3</th>\n",
-                     "      <td>Insect-repelling Plants &amp; New Organic Pesticide</td>\n",
-                     "      <td>Environmental Engineering</td>\n",
-                     "      <td>2014</td>\n",
-                     "      <td>set()</td>\n",
-                     "      <td>Organochlorine pesticides in agriculture are n...</td>\n",
-                     "      <td>United States of America</td>\n",
-                     "      <td>TX</td>\n",
-                     "      <td>NaN</td>\n",
-                     "      <td>['nan']</td>\n",
-                     "    </tr>\n",
-                     "    <tr>\n",
-                     "      <th>4</th>\n",
-                     "      <td>How Do Different Factors Affect the Accuracy o...</td>\n",
-                     "      <td>Earth and Environmental Sciences</td>\n",
-                     "      <td>2014</td>\n",
-                     "      <td>set()</td>\n",
-                     "      <td>The purpose of this experiment is to determine...</td>\n",
-                     "      <td>United States of America</td>\n",
-                     "      <td>MN</td>\n",
-                     "      <td>NaN</td>\n",
-                     "      <td>['nan']</td>\n",
-                     "    </tr>\n",
-                     "    <tr>\n",
-                     "      <th>5</th>\n",
-                     "      <td>Dye Sensitized Solar Cells: New Structures and...</td>\n",
-                     "      <td>Engineering Mechanics</td>\n",
-                     "      <td>2014</td>\n",
-                     "      <td>set()</td>\n",
-                     "      <td>Although fossil fuels have the capacity to pow...</td>\n",
-                     "      <td>United States of America</td>\n",
-                     "      <td>TX</td>\n",
-                     "      <td>NaN</td>\n",
-                     "      <td>['Fourth Award of $500']</td>\n",
-                     "    </tr>\n",
-                     "    <tr>\n",
-                     "      <th>6</th>\n",
-                     "      <td>A Novel Method for Determination of Camera Pos...</td>\n",
-                     "      <td>Embedded Systems</td>\n",
-                     "      <td>2014</td>\n",
-                     "      <td>set()</td>\n",
-                     "      <td>The method proposed here solves for the pose o...</td>\n",
-                     "      <td>United States of America</td>\n",
-                     "      <td>MO</td>\n",
-                     "      <td>NaN</td>\n",
-                     "      <td>['nan']</td>\n",
-                     "    </tr>\n",
-                     "    <tr>\n",
-                     "      <th>7</th>\n",
-                     "      <td>Observational Detection of Solar g-mode Oscill...</td>\n",
-                     "      <td>Microbiology</td>\n",
-                     "      <td>2014</td>\n",
-                     "      <td>set()</td>\n",
-                     "      <td>NaN</td>\n",
-                     "      <td>United States of America</td>\n",
-                     "      <td>HI</td>\n",
-                     "      <td>NaN</td>\n",
-                     "      <td>['Third Award of $1,000']</td>\n",
-                     "    </tr>\n",
-                     "    <tr>\n",
-                     "      <th>8</th>\n",
-                     "      <td>Synthesis of Periodic Mesoporous Organosilicas...</td>\n",
-                     "      <td>Plant Sciences</td>\n",
-                     "      <td>2014</td>\n",
-                     "      <td>set()</td>\n",
-                     "      <td>NaN</td>\n",
-                     "      <td>United States of America</td>\n",
-                     "      <td>TX</td>\n",
-                     "      <td>NaN</td>\n",
-                     "      <td>['Second Award of $2,000']</td>\n",
-                     "    </tr>\n",
-                     "    <tr>\n",
-                     "      <th>9</th>\n",
-                     "      <td>A Novel Mathematical Simulation to Study the D...</td>\n",
-                     "      <td>Materials Science</td>\n",
-                     "      <td>2014</td>\n",
-                     "      <td>set()</td>\n",
-                     "      <td>The purpose of the project was to determine if...</td>\n",
-                     "      <td>United States of America</td>\n",
-                     "      <td>FL</td>\n",
-                     "      <td>NaN</td>\n",
-                     "      <td>['nan']</td>\n",
-                     "    </tr>\n",
-                     "  </tbody>\n",
-                     "</table>\n",
-                     "</div>"
-                  ],
-                  "text/plain": [
-                     "                                               title  \\\n",
-                     "0  Dynamic Response of a Human Neck Replica to Ax...   \n",
-                     "1  The Effect of Nutrient Solution Concentration ...   \n",
-                     "2  Do Air Root Pruning Pots Accelerate Success in...   \n",
-                     "3    Insect-repelling Plants & New Organic Pesticide   \n",
-                     "4  How Do Different Factors Affect the Accuracy o...   \n",
-                     "5  Dye Sensitized Solar Cells: New Structures and...   \n",
-                     "6  A Novel Method for Determination of Camera Pos...   \n",
-                     "7  Observational Detection of Solar g-mode Oscill...   \n",
-                     "8  Synthesis of Periodic Mesoporous Organosilicas...   \n",
-                     "9  A Novel Approach to Solar Desalination Using N...   \n",
-                     "\n",
-                     "                           category  year schools  \\\n",
-                     "0                  Energy: Physical  2014   set()   \n",
-                     "1             Physics and Astronomy  2014   set()   \n",
-                     "2             Physics and Astronomy  2014   set()   \n",
-                     "3         Environmental Engineering  2014   set()   \n",
-                     "4  Earth and Environmental Sciences  2014   set()   \n",
-                     "5             Engineering Mechanics  2014   set()   \n",
-                     "6                  Embedded Systems  2014   set()   \n",
-                     "7                      Microbiology  2014   set()   \n",
-                     "8                    Plant Sciences  2014   set()   \n",
-                     "9                 Materials Science  2014   set()   \n",
-                     "\n",
-                     "                                            abstract  \\\n",
-                     "0  Purpose: A human neck replica was made to simu...   \n",
-                     "1  Studies comparing the mineral nutrition of hyd...   \n",
-                     "2  The purpose of my project was to determine whi...   \n",
-                     "3  Organochlorine pesticides in agriculture are n...   \n",
-                     "4  The purpose of this experiment is to determine...   \n",
-                     "5  Although fossil fuels have the capacity to pow...   \n",
-                     "6  The method proposed here solves for the pose o...   \n",
-                     "7                                                NaN   \n",
-                     "8                                                NaN   \n",
-                     "9  The purpose of the project was to determine if...   \n",
-                     "\n",
-                     "                    country State  Province                      awards  \n",
-                     "0  United States of America    MN       NaN                     ['nan']  \n",
-                     "1  United States of America    UT       NaN                     ['nan']  \n",
-                     "2  United States of America    LA       NaN                     ['nan']  \n",
-                     "3  United States of America    TX       NaN                     ['nan']  \n",
-                     "4  United States of America    MN       NaN                     ['nan']  \n",
-                     "5  United States of America    TX       NaN    ['Fourth Award of $500']  \n",
-                     "6  United States of America    MO       NaN                     ['nan']  \n",
-                     "7  United States of America    HI       NaN   ['Third Award of $1,000']  \n",
-                     "8  United States of America    TX       NaN  ['Second Award of $2,000']  \n",
-                     "9  United States of America    TX       NaN                     ['nan']  "
-                  ]
-               },
-               "execution_count": 9,
-               "metadata": {},
-               "output_type": "execute_result"
-            }
-         ],
-         "source": [
-            "df = pd.read_csv(INPUT_PATH)\n",
-            "\n",
-            "df.head(10)"
-         ]
-      },
-      {
-         "cell_type": "code",
-         "execution_count": 10,
-         "id": "78b7ffd3-6c43-4a6c-9ead-643ec284688f",
-         "metadata": {},
-         "outputs": [],
-         "source": [
-            "# Validate required columns\n",
-            "missing_columns: list[str] = [\n",
-            "    col for col in [KEY_COLUMN, EVAL_COLUMN] if col not in df.columns\n",
-            "]\n",
-            "if missing_columns:\n",
-            "    raise KeyError(f\"Missing required column(s): {', '.join(missing_columns)}\")\n",
-            "\n",
-            "# Ensure key column is of string type\n",
-            "df[KEY_COLUMN] = df[KEY_COLUMN].astype(str)"
-         ]
-      },
-      {
-         "cell_type": "markdown",
-         "id": "795ea766-76ab-46a1-a903-7895140e22fb",
-         "metadata": {},
-         "source": [
-            "# Load and Configure the LLM"
-         ]
-      },
-      {
-         "cell_type": "code",
-         "execution_count": 12,
-         "id": "31a6cbca-3b15-428a-ab5d-eba84351a663",
-         "metadata": {},
-         "outputs": [
-            {
-               "name": "stdout",
-               "output_type": "stream",
-               "text": [
-                  "CPU times: user 572 ms, sys: 2.79 s, total: 3.36 s\n",
-                  "Wall time: 52.8 s\n"
-               ]
-            }
-         ],
-         "source": [
-            "%%time\n",
-            "\n",
-            "llm: Llama = Llama(\n",
-            "    model_path=model_path,                       # Path to the local GGUF model file (config-based)\n",
-            "    n_gpu_layers=-1,                             # Load all layers to GPU if available\n",
-            "    n_batch=128,                                 # Number of tokens processed per batch\n",
-            "    n_ctx=8192,                                  # Context window size (max tokens the model can attend to)\n",
-            "    max_tokens=16,                               # Max tokens to generate per response\n",
-            "    f16_kv=True,                                 # Use 16-bit key/value memory for reduced memory usage\n",
-            "    use_mmap=False,                              # Memory-map model to improve loading efficiency\n",
-            "    low_vram=True,                               # Optimize for systems with low GPU memory\n",
-            "    rope_scaling=None,                           # Positional encoding scaling (None = default behavior)\n",
-            "    temperature=0.0,                             # Deterministic output (0 = greedy decoding)\n",
-            "    repeat_penalty=1.0,                          # No penalty for repeating tokens\n",
-            "    streaming=False,                             # Disable token streaming (batch output only)\n",
-            "    stop=None,                                   # No custom stop sequences\n",
-            "    seed=42,                                     # Set random seed for reproducibility\n",
-            "    num_threads=multiprocessing.cpu_count(),     # Use all available CPU cores\n",
-            "    verbose=False,                               # Disable verbose logging\n",
-            ")"
-         ]
-      },
-      {
-         "cell_type": "markdown",
-         "id": "895ed27f-6524-4e93-9a44-1d722a02f6fa",
-         "metadata": {},
-         "source": [
-            "# Define Helper Functions"
-         ]
-      },
-      {
-         "cell_type": "code",
-         "execution_count": 13,
-         "id": "3b120ba5-4fef-4c04-8324-fb25f539b197",
-         "metadata": {},
-         "outputs": [],
-         "source": [
-            "# ─── Helper Functions ───────────────────────────────────────────────────────\n",
-            "\n",
-            "def scale_score(raw_score: int, max_target: int) -> int:\n",
-            "    \"\"\"\n",
-            "    Scales a score from a 1–10 range to the given max_target range.\n",
-            "    Clamps the result between 0 and max_target.\n",
-            "    \"\"\"\n",
-            "    scaled: int = round((raw_score / 10) * max_target)\n",
-            "    return min(max(scaled, 0), max_target)\n",
-            "\n",
-            "\n",
-            "def extract_single_score(output: str) -> int:\n",
-            "    \"\"\"\n",
-            "    Extracts a single integer score (1–10) from the LLM output.\n",
-            "    Returns -1 if no valid score is found.\n",
-            "    \"\"\"\n",
-            "    match = re.search(r\"\\b(10|[1-9])\\b\", output)\n",
-            "    return int(match.group(1)) if match else -1\n",
-            "\n",
-            "\n",
-            "def evaluate_criterion(text: str, criterion: str) -> int:\n",
-            "    \"\"\"\n",
-            "    Prompts the LLM to score the text based on a specific criterion.\n",
-            "    Returns the extracted integer score from the LLM's response.\n",
-            "    \"\"\"\n",
-            "    if not isinstance(text, str):\n",
-            "        return -1\n",
-            "\n",
-            "    prompt: str = (\n",
-            "        f\"You are an expert evaluator. Rate the abstract below based solely on the criterion: '{criterion}'.\\n\"\n",
-            "        \"Provide a single integer from 1 to 10 (inclusive).\\n\"\n",
-            "        \"Output only the number — no words, labels, punctuation, or explanations.\\n\\n\"\n",
-            "        f\"Abstract:\\n{text.strip()}\\n\\n\"\n",
-            "        \"Score:\"\n",
-            "    )\n",
-            "\n",
-            "\n",
-            "    response: str = llm(prompt)[\"choices\"][0][\"text\"]\n",
-            "    return extract_single_score(response)\n",
-            "\n",
-            "\n",
-            "def evaluate_row(text: str, criteria: Dict) -> Dict[str, int]:\n",
-            "    \"\"\"\n",
-            "    Evaluates a single text against all rubric criteria.\n",
-            "    Returns a dictionary of scaled scores.\n",
-            "    \"\"\"\n",
-            "    return {\n",
-            "        criterion: scale_score(\n",
-            "            evaluate_criterion(text, criterion),\n",
-            "            criteria[criterion]\n",
-            "        )\n",
-            "        for criterion in criteria\n",
-            "    }"
-         ]
-      },
-      {
-         "cell_type": "markdown",
-         "id": "24d70b9d-39cc-46fd-9893-ba503896eb18",
-         "metadata": {},
-         "source": [
-            "# Run Evaluation"
-         ]
-      },
-      {
-         "cell_type": "code",
-         "execution_count": null,
-         "id": "e223420d-281d-4c85-bc0f-edd401992c6e",
-         "metadata": {},
-         "outputs": [
-            {
-               "data": {
-                  "application/vnd.jupyter.widget-view+json": {
-                     "model_id": "7643f1922cb14a1fb3206aac6a956fa6",
-                     "version_major": 2,
-                     "version_minor": 0
-                  },
-                  "text/plain": [
-                     "Evaluating rows:   0%|          | 0/19 [00:00<?, ?it/s]"
-                  ]
-               },
-               "metadata": {},
-               "output_type": "display_data"
-            },
-            {
-               "name": "stdout",
-               "output_type": "stream",
-               "text": [
-                  "CPU times: user 25.3 s, sys: 1.02 s, total: 26.4 s\n",
-                  "Wall time: 26.6 s\n"
-               ]
-            }
-         ],
-         "source": [
-            "%%time\n",
-            "\n",
-            "# Run evaluation over the selected DataFrame rows\n",
-            "evaluation_results: list[dict[str, Any]] = []\n",
-            "\n",
-            "for _, row in tqdm(df.iterrows(), total=len(df), desc=\"Evaluating rows\"):\n",
-            "    evaluated_row: dict[str, Any] = evaluate_row(row[EVAL_COLUMN], CRITERIA)\n",
-            "    evaluated_row[KEY_COLUMN] = row[KEY_COLUMN]\n",
-            "    evaluation_results.append(evaluated_row)\n",
-            "\n",
-            "# Convert results to a DataFrame\n",
-            "evaluation_df: pd.DataFrame = pd.DataFrame(evaluation_results)"
-         ]
-      },
-      {
-         "cell_type": "code",
-         "execution_count": 14,
-         "id": "18119587-3cd1-4665-9b53-ec1c4bb92f9e",
-         "metadata": {},
-         "outputs": [],
-         "source": [
-            "# Merge original data with evaluation results on the key column\n",
-            "final_df: pd.DataFrame = df.merge(evaluation_df, on=KEY_COLUMN)\n",
-            "\n",
-            "# Compute total score by summing across all criteria\n",
-            "final_df[\"TotalScore\"] = final_df[list(CRITERIA.keys())].sum(axis=1)\n",
-            "\n",
-            "# Sort the DataFrame by total score in descending order\n",
-            "final_df.sort_values(by=\"TotalScore\", ascending=False, inplace=True)"
-         ]
-      },
-      {
-         "cell_type": "markdown",
-         "id": "8f0adf0e-c1ad-4081-8ffb-9da19d52be28",
-         "metadata": {},
-         "source": [
-            "# Display Evaluation Results"
-         ]
-      },
-      {
-         "cell_type": "code",
-         "execution_count": null,
-         "id": "d6a6f322-905d-4a90-a849-09c26af8ddfa",
-         "metadata": {},
-         "outputs": [],
-         "source": [
-            "# Preview the top 10 evaluated entries\n",
-            "final_df.head(10)"
-         ]
-      },
-      {
-         "cell_type": "markdown",
-         "id": "4aba7408-c884-40ff-a655-b4bec1187e35",
-         "metadata": {},
-         "source": [
-            "# Save Evaluation Results"
-         ]
-      },
-      {
-         "cell_type": "code",
-         "execution_count": null,
-         "id": "58eb76ac-c4e5-4fa6-a2d2-8340b9e435b8",
-         "metadata": {},
-         "outputs": [],
-         "source": [
-            "final_df.to_csv(OUTPUT_PATH, index=False)\n",
-            "logger.info(f\"✅ Evaluation results successfully saved to: {OUTPUT_PATH}\")"
-         ]
-      },
-      {
-         "cell_type": "code",
-         "execution_count": null,
-         "id": "3513be69-3017-43b3-bb55-43acfae2aa31",
-         "metadata": {},
-         "outputs": [],
-         "source": [
-            "end_time: float = time.time()\n",
-            "elapsed_time: float = end_time - start_time\n",
-            "elapsed_minutes: int = int(elapsed_time // 60)\n",
-            "elapsed_seconds: float = elapsed_time % 60\n",
-            "\n",
-            "logger.info(f\"⏱️ Total execution time: {elapsed_minutes}m {elapsed_seconds:.2f}s\")\n",
-            "logger.info(\"✅ Notebook execution completed successfully.\")"
-         ]
-      },
-      {
-         "cell_type": "markdown",
-         "id": "8a3f2dd9-3f88-4aa4-bb2a-1b0af77f122f",
-         "metadata": {},
-         "source": [
-            "Built with ❤️ using [**HP AI Studio**](https://hp.com/ai-studio)."
-         ]
-      }
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "66cd861d-17bd-49a7-bfcc-01bf5ba3aba6",
+   "metadata": {},
+   "source": [
+    "<h1 style=\\\"text-align: center; font-size: 50px;\\\"> Run Workflow </h1>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0a095647-8f3b-412f-a249-71f34dbbdd08",
+   "metadata": {},
+   "source": [
+    "# Notebook Overview\n",
+    "\n",
+    "- Start Execution\n",
+    "- Define User Constants\n",
+    "- Install and Import Libraries\n",
+    "- Configure Settings\n",
+    "- Verify Assets\n",
+    "- Load and Validate Data\n",
+    "- Load and Configure the LLM\n",
+    "- Define Helper Functions\n",
+    "- Run Evaluation\n",
+    "- Display Evaluation Results\n",
+    "- Save Evaluation Results"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a5b811b4-c330-482b-af25-b23cb8183a68",
+   "metadata": {},
+   "source": [
+    "# Start Execution"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "af1d5c21-f2db-4cbe-9695-e835c49b4dc8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# -----------------------------\n",
+    "# Standard library imports\n",
+    "# -----------------------------\n",
+    "import os                   # Operating system utilities (paths, env vars, etc.)\n",
+    "import sys                  # Python runtime environment manipulation\n",
+    "import time                 # Time-related utilities\n",
+    "from datetime import datetime  # Date and time handling\n",
+    "from pathlib import Path     # Object-oriented filesystem paths\n",
+    "\n",
+    "# -----------------------------\n",
+    "# Local imports\n",
+    "# -----------------------------\n",
+    "# Extend sys.path to allow importing from parent directory\n",
+    "sys.path.append(os.path.abspath(os.path.join(os.getcwd(), \"..\")))\n",
+    "\n",
+    "from src.utils import logger  # Project-specific logging utility"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "7000405f-24cb-4ea0-bb5c-6ba3425343df",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "        <div style=\"background-color: #228B22; color: white;\n",
+       "                    padding: 4px 8px; font-family: monospace; border-radius: 4px;\">\n",
+       "            ✅ 2026-04-06 15:38:44 - INFO - Notebook execution started.\n",
+       "        </div>\n",
+       "        "
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
    ],
-   "metadata": {
-      "kernelspec": {
-         "display_name": "Python [conda env:base] *",
-         "language": "python",
-         "name": "conda-base-py"
+   "source": [
+    "start_time = time.time()  \n",
+    "logger.info(\"Notebook execution started.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "87a7247b-8643-4efe-b4bc-1a4e9bd4493b",
+   "metadata": {},
+   "source": [
+    "# Define User Constants"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "4b2bdc9e-8314-42b3-aaf3-c7c036c8f1b0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# File configuration\n",
+    "INPUT_FILE_NAME: str = \"2025 ISEF Project Abstracts.csv\"\n",
+    "INPUT_DIR: Path = Path(\"../data/inputs\")\n",
+    "OUTPUT_DIR: Path = Path(\"../data/outputs\")\n",
+    "\n",
+    "# Ensure directories exist\n",
+    "INPUT_DIR.mkdir(parents=True, exist_ok=True)\n",
+    "OUTPUT_DIR.mkdir(parents=True, exist_ok=True)\n",
+    "\n",
+    "INPUT_PATH: Path = INPUT_DIR / INPUT_FILE_NAME\n",
+    "TIMESTAMP: str = datetime.now().strftime('%Y-%m-%d %H-%M-%S')\n",
+    "OUTPUT_FILE_NAME: str = f\"Evaluated - {INPUT_FILE_NAME} - {TIMESTAMP}.csv\"\n",
+    "OUTPUT_PATH: Path = OUTPUT_DIR / OUTPUT_FILE_NAME\n",
+    "\n",
+    "LLAMA_MODEL_PATH = \"/home/jovyan/datafabric/meta-llama3.1-8b-Q8/Meta-Llama-3.1-8B-Instruct-Q8_0.gguf\"\n",
+    "\n",
+    "# Evaluation configuration\n",
+    "KEY_COLUMN: str = \"title\"\n",
+    "EVAL_COLUMN: str = \"abstract\"\n",
+    "CRITERIA: dict[str, int] = {\n",
+    "    \"Originality\": 3,\n",
+    "    \"ScientificRigor\": 4,\n",
+    "    \"Clarity\": 2,\n",
+    "    \"Relevance\": 1,\n",
+    "    \"Feasibility\": 3,\n",
+    "    \"Brevity\": 2,\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2d705e35-8e1d-4e94-80b5-ea276c8a5662",
+   "metadata": {},
+   "source": [
+    "# Install and Import Libraries"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "23ab0175-d6b0-4ffc-8026-dd0de3813310",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Note: you may need to restart the kernel to use updated packages.\n",
+      "CPU times: user 171 ms, sys: 56.7 ms, total: 228 ms\n",
+      "Wall time: 12.2 s\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%time\n",
+    "\n",
+    "%pip install -r ../requirements.txt --quiet"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "734b268e-3e02-4d07-9104-139e1f75e608",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# -----------------------------\n",
+    "# Standard library imports\n",
+    "# -----------------------------\n",
+    "import multiprocessing  # Provides process-based parallelism\n",
+    "import os               # Interacts with the operating system (paths, env vars, files)\n",
+    "import re               # Regular expression matching and text processing\n",
+    "import sys              # Access to interpreter variables and system functions\n",
+    "import warnings         # Control and display of warning messages\n",
+    "from typing import Any, Dict, List  # Type hints for annotations\n",
+    "\n",
+    "import pandas as pd\n",
+    "from tqdm.auto import tqdm\n",
+    "from llama_cpp import Llama\n",
+    "\n",
+    "sys.path.append(os.path.abspath(os.path.join(os.getcwd(), \"..\")))\n",
+    "\n",
+    "# === Project-Specific Imports (from src.utils) ===\n",
+    "from src.utils import load_config, configure_proxy"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a139ab4f-84d5-4aed-b34c-550fc32c6e16",
+   "metadata": {},
+   "source": [
+    "# Configure Settings"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "1335264b-de7c-41d9-8104-15e7f16ab4c6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "warnings.filterwarnings(\"ignore\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "5b52b18f-9065-4376-ab35-2e7caf485203",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Configuration loaded successfully\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Load configuration\n",
+    "CONFIG_PATH = \"../configs/config.yaml\"\n",
+    "config = load_config(CONFIG_PATH)\n",
+    "\n",
+    "model_path = config.get(\"model_path\")\n",
+    "\n",
+    "# Configure proxy if specified\n",
+    "configure_proxy(config)\n",
+    "\n",
+    "print(\"✅ Configuration loaded successfully\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "316487ad-0590-4963-aa17-5d2d1d6eb6c8",
+   "metadata": {},
+   "source": [
+    "# Verify Assets"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "2fff1675-6400-440b-8a96-7bd1ae098558",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def log_asset_status(asset_path: str, asset_name: str) -> None:\n",
+    "    \"\"\"\n",
+    "    Logs the status of a given asset based on its existence.\n",
+    "\n",
+    "    Parameters:\n",
+    "        asset_path (str): File or directory path to check.\n",
+    "        asset_name (str): Name of the asset for logging context.\n",
+    "    \"\"\"\n",
+    "    if Path(asset_path).exists():\n",
+    "        logger.info(f\"{asset_name} is properly configured.\")\n",
+    "    else:\n",
+    "        logger.info(f\"{asset_name} is not properly configured. Please ensure the required asset is correctly configured in your AI Studio project according to the README file.\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "375e6d07-77eb-4047-8137-94999f7bf863",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "        <div style=\"background-color: #228B22; color: white;\n",
+       "                    padding: 4px 8px; font-family: monospace; border-radius: 4px;\">\n",
+       "            ✅ 2026-04-06 15:39:08 - INFO - Input Data is properly configured.\n",
+       "        </div>\n",
+       "        "
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "        <div style=\"background-color: #228B22; color: white;\n",
+       "                    padding: 4px 8px; font-family: monospace; border-radius: 4px;\">\n",
+       "            ✅ 2026-04-06 15:39:08 - INFO - LLaMA Local model is properly configured.\n",
+       "        </div>\n",
+       "        "
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "log_asset_status(\n",
+    "    asset_path=INPUT_PATH,\n",
+    "    asset_name=\"Input Data\",\n",
+    ")\n",
+    "\n",
+    "log_asset_status(\n",
+    "    asset_path=model_path,\n",
+    "    asset_name=\"LLaMA Local model\",\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "66303ae6-4cb7-4417-a3eb-c4208e75a8e5",
+   "metadata": {},
+   "source": [
+    "# Load and Validate Data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "fed09dd6-0fbb-4dc5-b181-6bb41bb60ba0",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>title</th>\n",
+       "      <th>category</th>\n",
+       "      <th>year</th>\n",
+       "      <th>schools</th>\n",
+       "      <th>abstract</th>\n",
+       "      <th>country</th>\n",
+       "      <th>State</th>\n",
+       "      <th>Province</th>\n",
+       "      <th>awards</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>Dynamic Response of a Human Neck Replica to Ax...</td>\n",
+       "      <td>Energy: Physical</td>\n",
+       "      <td>2014</td>\n",
+       "      <td>set()</td>\n",
+       "      <td>Purpose: A human neck replica was made to simu...</td>\n",
+       "      <td>United States of America</td>\n",
+       "      <td>MN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>['nan']</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>The Effect of Nutrient Solution Concentration ...</td>\n",
+       "      <td>Physics and Astronomy</td>\n",
+       "      <td>2014</td>\n",
+       "      <td>set()</td>\n",
+       "      <td>Studies comparing the mineral nutrition of hyd...</td>\n",
+       "      <td>United States of America</td>\n",
+       "      <td>UT</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>['nan']</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>Do Air Root Pruning Pots Accelerate Success in...</td>\n",
+       "      <td>Physics and Astronomy</td>\n",
+       "      <td>2014</td>\n",
+       "      <td>set()</td>\n",
+       "      <td>The purpose of my project was to determine whi...</td>\n",
+       "      <td>United States of America</td>\n",
+       "      <td>LA</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>['nan']</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>Insect-repelling Plants &amp; New Organic Pesticide</td>\n",
+       "      <td>Environmental Engineering</td>\n",
+       "      <td>2014</td>\n",
+       "      <td>set()</td>\n",
+       "      <td>Organochlorine pesticides in agriculture are n...</td>\n",
+       "      <td>United States of America</td>\n",
+       "      <td>TX</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>['nan']</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>How Do Different Factors Affect the Accuracy o...</td>\n",
+       "      <td>Earth and Environmental Sciences</td>\n",
+       "      <td>2014</td>\n",
+       "      <td>set()</td>\n",
+       "      <td>The purpose of this experiment is to determine...</td>\n",
+       "      <td>United States of America</td>\n",
+       "      <td>MN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>['nan']</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>5</th>\n",
+       "      <td>Dye Sensitized Solar Cells: New Structures and...</td>\n",
+       "      <td>Engineering Mechanics</td>\n",
+       "      <td>2014</td>\n",
+       "      <td>set()</td>\n",
+       "      <td>Although fossil fuels have the capacity to pow...</td>\n",
+       "      <td>United States of America</td>\n",
+       "      <td>TX</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>['Fourth Award of $500']</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>6</th>\n",
+       "      <td>A Novel Method for Determination of Camera Pos...</td>\n",
+       "      <td>Embedded Systems</td>\n",
+       "      <td>2014</td>\n",
+       "      <td>set()</td>\n",
+       "      <td>The method proposed here solves for the pose o...</td>\n",
+       "      <td>United States of America</td>\n",
+       "      <td>MO</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>['nan']</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>7</th>\n",
+       "      <td>Observational Detection of Solar g-mode Oscill...</td>\n",
+       "      <td>Microbiology</td>\n",
+       "      <td>2014</td>\n",
+       "      <td>set()</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>United States of America</td>\n",
+       "      <td>HI</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>['Third Award of $1,000']</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>8</th>\n",
+       "      <td>Synthesis of Periodic Mesoporous Organosilicas...</td>\n",
+       "      <td>Plant Sciences</td>\n",
+       "      <td>2014</td>\n",
+       "      <td>set()</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>United States of America</td>\n",
+       "      <td>TX</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>['Second Award of $2,000']</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>9</th>\n",
+       "      <td>A Novel Approach to Solar Desalination Using N...</td>\n",
+       "      <td>Plant Sciences</td>\n",
+       "      <td>2014</td>\n",
+       "      <td>set()</td>\n",
+       "      <td>The purpose of the project was to determine if...</td>\n",
+       "      <td>United States of America</td>\n",
+       "      <td>FL</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>['nan']</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                                               title  \\\n",
+       "0  Dynamic Response of a Human Neck Replica to Ax...   \n",
+       "1  The Effect of Nutrient Solution Concentration ...   \n",
+       "2  Do Air Root Pruning Pots Accelerate Success in...   \n",
+       "3    Insect-repelling Plants & New Organic Pesticide   \n",
+       "4  How Do Different Factors Affect the Accuracy o...   \n",
+       "5  Dye Sensitized Solar Cells: New Structures and...   \n",
+       "6  A Novel Method for Determination of Camera Pos...   \n",
+       "7  Observational Detection of Solar g-mode Oscill...   \n",
+       "8  Synthesis of Periodic Mesoporous Organosilicas...   \n",
+       "9  A Novel Approach to Solar Desalination Using N...   \n",
+       "\n",
+       "                           category  year schools  \\\n",
+       "0                  Energy: Physical  2014   set()   \n",
+       "1             Physics and Astronomy  2014   set()   \n",
+       "2             Physics and Astronomy  2014   set()   \n",
+       "3         Environmental Engineering  2014   set()   \n",
+       "4  Earth and Environmental Sciences  2014   set()   \n",
+       "5             Engineering Mechanics  2014   set()   \n",
+       "6                  Embedded Systems  2014   set()   \n",
+       "7                      Microbiology  2014   set()   \n",
+       "8                    Plant Sciences  2014   set()   \n",
+       "9                    Plant Sciences  2014   set()   \n",
+       "\n",
+       "                                            abstract  \\\n",
+       "0  Purpose: A human neck replica was made to simu...   \n",
+       "1  Studies comparing the mineral nutrition of hyd...   \n",
+       "2  The purpose of my project was to determine whi...   \n",
+       "3  Organochlorine pesticides in agriculture are n...   \n",
+       "4  The purpose of this experiment is to determine...   \n",
+       "5  Although fossil fuels have the capacity to pow...   \n",
+       "6  The method proposed here solves for the pose o...   \n",
+       "7                                                NaN   \n",
+       "8                                                NaN   \n",
+       "9  The purpose of the project was to determine if...   \n",
+       "\n",
+       "                    country State  Province                      awards  \n",
+       "0  United States of America    MN       NaN                     ['nan']  \n",
+       "1  United States of America    UT       NaN                     ['nan']  \n",
+       "2  United States of America    LA       NaN                     ['nan']  \n",
+       "3  United States of America    TX       NaN                     ['nan']  \n",
+       "4  United States of America    MN       NaN                     ['nan']  \n",
+       "5  United States of America    TX       NaN    ['Fourth Award of $500']  \n",
+       "6  United States of America    MO       NaN                     ['nan']  \n",
+       "7  United States of America    HI       NaN   ['Third Award of $1,000']  \n",
+       "8  United States of America    TX       NaN  ['Second Award of $2,000']  \n",
+       "9  United States of America    FL       NaN                     ['nan']  "
+      ]
+     },
+     "execution_count": 10,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df = pd.read_csv(INPUT_PATH)\n",
+    "\n",
+    "df.head(10)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "78b7ffd3-6c43-4a6c-9ead-643ec284688f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Validate required columns\n",
+    "missing_columns: list[str] = [\n",
+    "    col for col in [KEY_COLUMN, EVAL_COLUMN] if col not in df.columns\n",
+    "]\n",
+    "if missing_columns:\n",
+    "    raise KeyError(f\"Missing required column(s): {', '.join(missing_columns)}\")\n",
+    "\n",
+    "# Ensure key column is of string type\n",
+    "df[KEY_COLUMN] = df[KEY_COLUMN].astype(str)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "795ea766-76ab-46a1-a903-7895140e22fb",
+   "metadata": {},
+   "source": [
+    "# Load and Configure the LLM"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "31a6cbca-3b15-428a-ab5d-eba84351a663",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "llama_context: n_ctx_per_seq (8192) < n_ctx_train (131072) -- the full capacity of the model will not be utilized\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CPU times: user 2.52 s, sys: 1.97 s, total: 4.49 s\n",
+      "Wall time: 55.5 s\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%time\n",
+    "\n",
+    "llm: Llama = Llama(\n",
+    "    model_path=model_path,                       # Path to the local GGUF model file (config-based)\n",
+    "    n_gpu_layers=-1,                             # Load all layers to GPU if available\n",
+    "    n_batch=128,                                 # Number of tokens processed per batch\n",
+    "    n_ctx=8192,                                  # Context window size (max tokens the model can attend to)\n",
+    "    max_tokens=16,                               # Max tokens to generate per response\n",
+    "    f16_kv=True,                                 # Use 16-bit key/value memory for reduced memory usage\n",
+    "    use_mmap=False,                              # Memory-map model to improve loading efficiency\n",
+    "    low_vram=True,                               # Optimize for systems with low GPU memory\n",
+    "    rope_scaling=None,                           # Positional encoding scaling (None = default behavior)\n",
+    "    temperature=0.0,                             # Deterministic output (0 = greedy decoding)\n",
+    "    repeat_penalty=1.0,                          # No penalty for repeating tokens\n",
+    "    streaming=False,                             # Disable token streaming (batch output only)\n",
+    "    stop=None,                                   # No custom stop sequences\n",
+    "    seed=42,                                     # Set random seed for reproducibility\n",
+    "    num_threads=multiprocessing.cpu_count(),     # Use all available CPU cores\n",
+    "    verbose=False,                               # Disable verbose logging\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "895ed27f-6524-4e93-9a44-1d722a02f6fa",
+   "metadata": {},
+   "source": [
+    "# Define Helper Functions"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "3b120ba5-4fef-4c04-8324-fb25f539b197",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# ─── Helper Functions ───────────────────────────────────────────────────────\n",
+    "\n",
+    "def scale_score(raw_score: int, max_target: int) -> int:\n",
+    "    \"\"\"\n",
+    "    Scales a score from a 1–10 range to the given max_target range.\n",
+    "    Clamps the result between 0 and max_target.\n",
+    "    \"\"\"\n",
+    "    scaled: int = round((raw_score / 10) * max_target)\n",
+    "    return min(max(scaled, 0), max_target)\n",
+    "\n",
+    "\n",
+    "def extract_single_score(output: str) -> int:\n",
+    "    \"\"\"\n",
+    "    Extracts a single integer score (1–10) from the LLM output.\n",
+    "    Returns -1 if no valid score is found.\n",
+    "    \"\"\"\n",
+    "    match = re.search(r\"\\b(10|[1-9])\\b\", output)\n",
+    "    return int(match.group(1)) if match else -1\n",
+    "\n",
+    "\n",
+    "def evaluate_criterion(text: str, criterion: str) -> int:\n",
+    "    \"\"\"\n",
+    "    Prompts the LLM to score the text based on a specific criterion.\n",
+    "    Returns the extracted integer score from the LLM's response.\n",
+    "    \"\"\"\n",
+    "    if not isinstance(text, str):\n",
+    "        return -1\n",
+    "\n",
+    "    prompt: str = (\n",
+    "        f\"You are an expert evaluator. Rate the abstract below based solely on the criterion: '{criterion}'.\\n\"\n",
+    "        \"Provide a single integer from 1 to 10 (inclusive).\\n\"\n",
+    "        \"Output only the number — no words, labels, punctuation, or explanations.\\n\\n\"\n",
+    "        f\"Abstract:\\n{text.strip()}\\n\\n\"\n",
+    "        \"Score:\"\n",
+    "    )\n",
+    "\n",
+    "\n",
+    "    response: str = llm(prompt)[\"choices\"][0][\"text\"]\n",
+    "    return extract_single_score(response)\n",
+    "\n",
+    "\n",
+    "def evaluate_row(text: str, criteria: Dict) -> Dict[str, int]:\n",
+    "    \"\"\"\n",
+    "    Evaluates a single text against all rubric criteria.\n",
+    "    Returns a dictionary of scaled scores.\n",
+    "    \"\"\"\n",
+    "    return {\n",
+    "        criterion: scale_score(\n",
+    "            evaluate_criterion(text, criterion),\n",
+    "            criteria[criterion]\n",
+    "        )\n",
+    "        for criterion in criteria\n",
+    "    }"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "24d70b9d-39cc-46fd-9893-ba503896eb18",
+   "metadata": {},
+   "source": [
+    "# Run Evaluation"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "e223420d-281d-4c85-bc0f-edd401992c6e",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "6f3cec6d03e949faa1a80643daa777fb",
+       "version_major": 2,
+       "version_minor": 0
       },
-      "language_info": {
-         "codemirror_mode": {
-            "name": "ipython",
-            "version": 3
-         },
-         "file_extension": ".py",
-         "mimetype": "text/x-python",
-         "name": "python",
-         "nbconvert_exporter": "python",
-         "pygments_lexer": "ipython3",
-         "version": "3.12.7"
-      }
+      "text/plain": [
+       "Evaluating rows:   0%|          | 0/10 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CPU times: user 41min 10s, sys: 12min 7s, total: 53min 18s\n",
+      "Wall time: 53min 17s\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%time\n",
+    "\n",
+    "# Run evaluation over the selected DataFrame rows\n",
+    "evaluation_results: list[dict[str, Any]] = []\n",
+    "\n",
+    "for _, row in tqdm(df.iterrows(), total=len(df), desc=\"Evaluating rows\"):\n",
+    "    evaluated_row: dict[str, Any] = evaluate_row(row[EVAL_COLUMN], CRITERIA)\n",
+    "    evaluated_row[KEY_COLUMN] = row[KEY_COLUMN]\n",
+    "    evaluation_results.append(evaluated_row)\n",
+    "\n",
+    "# Convert results to a DataFrame\n",
+    "evaluation_df: pd.DataFrame = pd.DataFrame(evaluation_results)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "18119587-3cd1-4665-9b53-ec1c4bb92f9e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Merge original data with evaluation results on the key column\n",
+    "final_df: pd.DataFrame = df.merge(evaluation_df, on=KEY_COLUMN)\n",
+    "\n",
+    "# Compute total score by summing across all criteria\n",
+    "final_df[\"TotalScore\"] = final_df[list(CRITERIA.keys())].sum(axis=1)\n",
+    "\n",
+    "# Sort the DataFrame by total score in descending order\n",
+    "final_df.sort_values(by=\"TotalScore\", ascending=False, inplace=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8f0adf0e-c1ad-4081-8ffb-9da19d52be28",
+   "metadata": {},
+   "source": [
+    "# Display Evaluation Results"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "id": "d6a6f322-905d-4a90-a849-09c26af8ddfa",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>title</th>\n",
+       "      <th>category</th>\n",
+       "      <th>year</th>\n",
+       "      <th>schools</th>\n",
+       "      <th>abstract</th>\n",
+       "      <th>country</th>\n",
+       "      <th>State</th>\n",
+       "      <th>Province</th>\n",
+       "      <th>awards</th>\n",
+       "      <th>Originality</th>\n",
+       "      <th>ScientificRigor</th>\n",
+       "      <th>Clarity</th>\n",
+       "      <th>Relevance</th>\n",
+       "      <th>Feasibility</th>\n",
+       "      <th>Brevity</th>\n",
+       "      <th>TotalScore</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>Dynamic Response of a Human Neck Replica to Ax...</td>\n",
+       "      <td>Energy: Physical</td>\n",
+       "      <td>2014</td>\n",
+       "      <td>set()</td>\n",
+       "      <td>Purpose: A human neck replica was made to simu...</td>\n",
+       "      <td>United States of America</td>\n",
+       "      <td>MN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>['nan']</td>\n",
+       "      <td>2</td>\n",
+       "      <td>4</td>\n",
+       "      <td>2</td>\n",
+       "      <td>1</td>\n",
+       "      <td>3</td>\n",
+       "      <td>0</td>\n",
+       "      <td>12</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>The Effect of Nutrient Solution Concentration ...</td>\n",
+       "      <td>Physics and Astronomy</td>\n",
+       "      <td>2014</td>\n",
+       "      <td>set()</td>\n",
+       "      <td>Studies comparing the mineral nutrition of hyd...</td>\n",
+       "      <td>United States of America</td>\n",
+       "      <td>UT</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>['nan']</td>\n",
+       "      <td>1</td>\n",
+       "      <td>4</td>\n",
+       "      <td>2</td>\n",
+       "      <td>1</td>\n",
+       "      <td>2</td>\n",
+       "      <td>1</td>\n",
+       "      <td>11</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>9</th>\n",
+       "      <td>A Novel Approach to Solar Desalination Using N...</td>\n",
+       "      <td>Plant Sciences</td>\n",
+       "      <td>2014</td>\n",
+       "      <td>set()</td>\n",
+       "      <td>The purpose of the project was to determine if...</td>\n",
+       "      <td>United States of America</td>\n",
+       "      <td>FL</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>['nan']</td>\n",
+       "      <td>1</td>\n",
+       "      <td>2</td>\n",
+       "      <td>1</td>\n",
+       "      <td>1</td>\n",
+       "      <td>3</td>\n",
+       "      <td>1</td>\n",
+       "      <td>9</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>6</th>\n",
+       "      <td>A Novel Method for Determination of Camera Pos...</td>\n",
+       "      <td>Embedded Systems</td>\n",
+       "      <td>2014</td>\n",
+       "      <td>set()</td>\n",
+       "      <td>The method proposed here solves for the pose o...</td>\n",
+       "      <td>United States of America</td>\n",
+       "      <td>MO</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>['nan']</td>\n",
+       "      <td>1</td>\n",
+       "      <td>2</td>\n",
+       "      <td>2</td>\n",
+       "      <td>1</td>\n",
+       "      <td>2</td>\n",
+       "      <td>1</td>\n",
+       "      <td>9</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>Insect-repelling Plants &amp; New Organic Pesticide</td>\n",
+       "      <td>Environmental Engineering</td>\n",
+       "      <td>2014</td>\n",
+       "      <td>set()</td>\n",
+       "      <td>Organochlorine pesticides in agriculture are n...</td>\n",
+       "      <td>United States of America</td>\n",
+       "      <td>TX</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>['nan']</td>\n",
+       "      <td>1</td>\n",
+       "      <td>2</td>\n",
+       "      <td>1</td>\n",
+       "      <td>1</td>\n",
+       "      <td>2</td>\n",
+       "      <td>1</td>\n",
+       "      <td>8</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>5</th>\n",
+       "      <td>Dye Sensitized Solar Cells: New Structures and...</td>\n",
+       "      <td>Engineering Mechanics</td>\n",
+       "      <td>2014</td>\n",
+       "      <td>set()</td>\n",
+       "      <td>Although fossil fuels have the capacity to pow...</td>\n",
+       "      <td>United States of America</td>\n",
+       "      <td>TX</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>['Fourth Award of $500']</td>\n",
+       "      <td>1</td>\n",
+       "      <td>2</td>\n",
+       "      <td>1</td>\n",
+       "      <td>1</td>\n",
+       "      <td>2</td>\n",
+       "      <td>1</td>\n",
+       "      <td>8</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>How Do Different Factors Affect the Accuracy o...</td>\n",
+       "      <td>Earth and Environmental Sciences</td>\n",
+       "      <td>2014</td>\n",
+       "      <td>set()</td>\n",
+       "      <td>The purpose of this experiment is to determine...</td>\n",
+       "      <td>United States of America</td>\n",
+       "      <td>MN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>['nan']</td>\n",
+       "      <td>1</td>\n",
+       "      <td>1</td>\n",
+       "      <td>1</td>\n",
+       "      <td>1</td>\n",
+       "      <td>3</td>\n",
+       "      <td>0</td>\n",
+       "      <td>7</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>Do Air Root Pruning Pots Accelerate Success in...</td>\n",
+       "      <td>Physics and Astronomy</td>\n",
+       "      <td>2014</td>\n",
+       "      <td>set()</td>\n",
+       "      <td>The purpose of my project was to determine whi...</td>\n",
+       "      <td>United States of America</td>\n",
+       "      <td>LA</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>['nan']</td>\n",
+       "      <td>1</td>\n",
+       "      <td>2</td>\n",
+       "      <td>1</td>\n",
+       "      <td>0</td>\n",
+       "      <td>2</td>\n",
+       "      <td>1</td>\n",
+       "      <td>7</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>7</th>\n",
+       "      <td>Observational Detection of Solar g-mode Oscill...</td>\n",
+       "      <td>Microbiology</td>\n",
+       "      <td>2014</td>\n",
+       "      <td>set()</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>United States of America</td>\n",
+       "      <td>HI</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>['Third Award of $1,000']</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>8</th>\n",
+       "      <td>Synthesis of Periodic Mesoporous Organosilicas...</td>\n",
+       "      <td>Plant Sciences</td>\n",
+       "      <td>2014</td>\n",
+       "      <td>set()</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>United States of America</td>\n",
+       "      <td>TX</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>['Second Award of $2,000']</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                                               title  \\\n",
+       "0  Dynamic Response of a Human Neck Replica to Ax...   \n",
+       "1  The Effect of Nutrient Solution Concentration ...   \n",
+       "9  A Novel Approach to Solar Desalination Using N...   \n",
+       "6  A Novel Method for Determination of Camera Pos...   \n",
+       "3    Insect-repelling Plants & New Organic Pesticide   \n",
+       "5  Dye Sensitized Solar Cells: New Structures and...   \n",
+       "4  How Do Different Factors Affect the Accuracy o...   \n",
+       "2  Do Air Root Pruning Pots Accelerate Success in...   \n",
+       "7  Observational Detection of Solar g-mode Oscill...   \n",
+       "8  Synthesis of Periodic Mesoporous Organosilicas...   \n",
+       "\n",
+       "                           category  year schools  \\\n",
+       "0                  Energy: Physical  2014   set()   \n",
+       "1             Physics and Astronomy  2014   set()   \n",
+       "9                    Plant Sciences  2014   set()   \n",
+       "6                  Embedded Systems  2014   set()   \n",
+       "3         Environmental Engineering  2014   set()   \n",
+       "5             Engineering Mechanics  2014   set()   \n",
+       "4  Earth and Environmental Sciences  2014   set()   \n",
+       "2             Physics and Astronomy  2014   set()   \n",
+       "7                      Microbiology  2014   set()   \n",
+       "8                    Plant Sciences  2014   set()   \n",
+       "\n",
+       "                                            abstract  \\\n",
+       "0  Purpose: A human neck replica was made to simu...   \n",
+       "1  Studies comparing the mineral nutrition of hyd...   \n",
+       "9  The purpose of the project was to determine if...   \n",
+       "6  The method proposed here solves for the pose o...   \n",
+       "3  Organochlorine pesticides in agriculture are n...   \n",
+       "5  Although fossil fuels have the capacity to pow...   \n",
+       "4  The purpose of this experiment is to determine...   \n",
+       "2  The purpose of my project was to determine whi...   \n",
+       "7                                                NaN   \n",
+       "8                                                NaN   \n",
+       "\n",
+       "                    country State  Province                      awards  \\\n",
+       "0  United States of America    MN       NaN                     ['nan']   \n",
+       "1  United States of America    UT       NaN                     ['nan']   \n",
+       "9  United States of America    FL       NaN                     ['nan']   \n",
+       "6  United States of America    MO       NaN                     ['nan']   \n",
+       "3  United States of America    TX       NaN                     ['nan']   \n",
+       "5  United States of America    TX       NaN    ['Fourth Award of $500']   \n",
+       "4  United States of America    MN       NaN                     ['nan']   \n",
+       "2  United States of America    LA       NaN                     ['nan']   \n",
+       "7  United States of America    HI       NaN   ['Third Award of $1,000']   \n",
+       "8  United States of America    TX       NaN  ['Second Award of $2,000']   \n",
+       "\n",
+       "   Originality  ScientificRigor  Clarity  Relevance  Feasibility  Brevity  \\\n",
+       "0            2                4        2          1            3        0   \n",
+       "1            1                4        2          1            2        1   \n",
+       "9            1                2        1          1            3        1   \n",
+       "6            1                2        2          1            2        1   \n",
+       "3            1                2        1          1            2        1   \n",
+       "5            1                2        1          1            2        1   \n",
+       "4            1                1        1          1            3        0   \n",
+       "2            1                2        1          0            2        1   \n",
+       "7            0                0        0          0            0        0   \n",
+       "8            0                0        0          0            0        0   \n",
+       "\n",
+       "   TotalScore  \n",
+       "0          12  \n",
+       "1          11  \n",
+       "9           9  \n",
+       "6           9  \n",
+       "3           8  \n",
+       "5           8  \n",
+       "4           7  \n",
+       "2           7  \n",
+       "7           0  \n",
+       "8           0  "
+      ]
+     },
+     "execution_count": 16,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Preview the top 10 evaluated entries\n",
+    "final_df.head(10)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4aba7408-c884-40ff-a655-b4bec1187e35",
+   "metadata": {},
+   "source": [
+    "# Save Evaluation Results"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "58eb76ac-c4e5-4fa6-a2d2-8340b9e435b8",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "        <div style=\"background-color: #228B22; color: white;\n",
+       "                    padding: 4px 8px; font-family: monospace; border-radius: 4px;\">\n",
+       "            ✅ 2026-04-06 16:35:57 - INFO - ✅ Evaluation results successfully saved to: ../data/outputs/Evaluated - 2025 ISEF Project Abstracts.csv - 2026-04-06 15-38-45.csv\n",
+       "        </div>\n",
+       "        "
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# Free GPU VRAM by deleting the LLM instance\n",
+    "del llm\n",
+    "\n",
+    "final_df.to_csv(OUTPUT_PATH, index=False)\n",
+    "logger.info(f\"✅ Evaluation results successfully saved to: {OUTPUT_PATH}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "id": "3513be69-3017-43b3-bb55-43acfae2aa31",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "        <div style=\"background-color: #228B22; color: white;\n",
+       "                    padding: 4px 8px; font-family: monospace; border-radius: 4px;\">\n",
+       "            ✅ 2026-04-06 16:35:59 - INFO - ⏱️ Total execution time: 57m 14.97s\n",
+       "        </div>\n",
+       "        "
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "        <div style=\"background-color: #228B22; color: white;\n",
+       "                    padding: 4px 8px; font-family: monospace; border-radius: 4px;\">\n",
+       "            ✅ 2026-04-06 16:35:59 - INFO - ✅ Notebook execution completed successfully.\n",
+       "        </div>\n",
+       "        "
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "end_time: float = time.time()\n",
+    "elapsed_time: float = end_time - start_time\n",
+    "elapsed_minutes: int = int(elapsed_time // 60)\n",
+    "elapsed_seconds: float = elapsed_time % 60\n",
+    "\n",
+    "logger.info(f\"⏱️ Total execution time: {elapsed_minutes}m {elapsed_seconds:.2f}s\")\n",
+    "logger.info(\"✅ Notebook execution completed successfully.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8a3f2dd9-3f88-4aa4-bb2a-1b0af77f122f",
+   "metadata": {},
+   "source": [
+    "Built with ❤️ using [**HP AI Studio**](https://hp.com/ai-studio)."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python [conda env:base] *",
+   "language": "python",
+   "name": "conda-base-py"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
    },
-   "nbformat": 4,
-   "nbformat_minor": 5
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.7"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
 }

--- a/generative-ai/code-generation-with-langchain/demo/streamlit/main.py
+++ b/generative-ai/code-generation-with-langchain/demo/streamlit/main.py
@@ -7,7 +7,6 @@ import numpy as np
 from pathlib import Path
 import json
 
-
 os.environ.setdefault("NO_PROXY", "localhost,127.0.0.1")
 # --- Streamlit Page Configuration ---
 st.set_page_config(

--- a/generative-ai/code-generation-with-langchain/src/utils.py
+++ b/generative-ai/code-generation-with-langchain/src/utils.py
@@ -13,7 +13,6 @@ from typing import Dict, Any, Optional, Union, List, Tuple
 from .trt_llm_langchain import TensorRTLangchain
 from langchain_core.language_models.llms import LLM  # For type hints
 
-
 # Default models to be loaded in our examples:
 DEFAULT_MODELS = {
     "local": "/home/jovyan/datafabric/meta-llama3.1-8b-Q8/Meta-Llama-3.1-8B-Instruct-Q8_0.gguf",

--- a/generative-ai/educational-quickstart/demo/chatbot/streamlit/main.py
+++ b/generative-ai/educational-quickstart/demo/chatbot/streamlit/main.py
@@ -159,14 +159,12 @@ for _cid in _stale:
 with st.sidebar:
     # ── Usage instructions ──
     st.title("⚙️ Usage")
-    st.markdown(
-        """
+    st.markdown("""
 **Instructions:**
 1. (Optional) Customize the system prompt below.
 2. Type your question and press **Enter**.
 3. The assistant will respond with an AI-generated answer.
-"""
-    )
+""")
 
     st.divider()
 

--- a/generative-ai/educational-quickstart/demo/document/streamlit/main.py
+++ b/generative-ai/educational-quickstart/demo/document/streamlit/main.py
@@ -58,14 +58,12 @@ st.markdown(
 
 # ───────────────────────────── Sidebar ─────────────────────────────────────────
 st.sidebar.title("⚙️ Usage")
-st.sidebar.markdown(
-    """
+st.sidebar.markdown("""
 **Instructions:**
 1. Paste or type your document text into the input field.
 2. Enter your question about the document.
 3. Click **Analyze Document** to receive an AI-generated answer.
-"""
-)
+""")
 
 endpoint_url = "http://localhost:5002/invocations"
 

--- a/generative-ai/educational-quickstart/demo/image_gen/streamlit/main.py
+++ b/generative-ai/educational-quickstart/demo/image_gen/streamlit/main.py
@@ -124,13 +124,11 @@ seed_value = st.sidebar.number_input(
 seed = int(seed_value) if use_fixed_seed else -1
 
 st.sidebar.divider()
-st.sidebar.markdown(
-    """
+st.sidebar.markdown("""
 **Instructions:**
 1. Adjust parameters above.
 2. Type a prompt and click **Generate Image**.
-"""
-)
+""")
 
 endpoint_url = "http://localhost:5002/invocations"
 

--- a/generative-ai/educational-quickstart/demo/voice/streamlit/main.py
+++ b/generative-ai/educational-quickstart/demo/voice/streamlit/main.py
@@ -109,15 +109,13 @@ st.markdown(
 
 # ───────────────────────────── Sidebar ─────────────────────────────────────────
 st.sidebar.title("⚙️ Usage")
-st.sidebar.markdown(
-    """
+st.sidebar.markdown("""
 **Instructions:**
 1. Record with your microphone or upload an audio file.
 2. Whisper transcribes the audio to text.
 3. The LLM generates a response.
 4. XTTS v2 speaks the response aloud.
-"""
-)
+""")
 
 endpoint_url = "http://localhost:5002/invocations"
 

--- a/generative-ai/educational-quickstart/src/mlflow/loader.py
+++ b/generative-ai/educational-quickstart/src/mlflow/loader.py
@@ -322,7 +322,9 @@ def _load_pyfunc(data_path: str):
     # ── 1. Load configuration ────────────────────────────────────────────────
     config_path = data_path / "config.yaml"
     if not config_path.exists():
-        logger.warning(f"⚠️ config.yaml not found at {config_path}. Using empty config.")
+        logger.warning(
+            f"⚠️ config.yaml not found at {config_path}. Using empty config."
+        )
         config = {}
     else:
         config = load_config(str(config_path))

--- a/generative-ai/educational-quickstart/src/utils.py
+++ b/generative-ai/educational-quickstart/src/utils.py
@@ -24,7 +24,6 @@ from IPython.display import (
     display,
 )  # Rich HTML display utilities — lets us show styled text and images inside Jupyter notebooks
 
-
 # ─────── Log Level Styles ────────────────────────────────────────────────────
 # Each log level (DEBUG, INFO, WARNING, etc.) gets its own background color and emoji icon.
 # This makes notebook output much easier to read at a glance.

--- a/generative-ai/grammar-correction-with-langchain/src/utils.py
+++ b/generative-ai/grammar-correction-with-langchain/src/utils.py
@@ -12,7 +12,6 @@ from IPython.display import (
     display,
 )  # Rich HTML display utilities for Jupyter environments
 
-
 # Color and emoji mapping per level
 STYLE_MAP = {
     logging.DEBUG: {"bg": "#1e90ff", "fg": "white", "icon": "🔍"},

--- a/generative-ai/image-generation-with-stablediffusion/core/dreambooth_inference/inference_dreambooth.py
+++ b/generative-ai/image-generation-with-stablediffusion/core/dreambooth_inference/inference_dreambooth.py
@@ -30,7 +30,6 @@ from src.utils import (
     get_model_cache_dir,
 )
 
-
 _CONFIG_FILENAMES = {
     "multi": "default_config_multi-gpu.yaml",
     "single": "default_config_one-gpu.yaml",

--- a/generative-ai/image-generation-with-stablediffusion/core/local_inference/inference.py
+++ b/generative-ai/image-generation-with-stablediffusion/core/local_inference/inference.py
@@ -24,7 +24,6 @@ from src.utils import (
     get_model_cache_dir,
 )
 
-
 _CONFIG_FILENAMES = {
     "multi": "default_config_multi-gpu.yaml",
     "single": "default_config_one-gpu.yaml",

--- a/generative-ai/text-generation-with-langchain/demo/streamlit/main.py
+++ b/generative-ai/text-generation-with-langchain/demo/streamlit/main.py
@@ -7,6 +7,7 @@ Streamlit front-end for the **Paper-to-Script** MLflow service.
   short presentation script.
 • The back-end must expose the standard MLflow `/invocations` endpoint.
 """
+
 from __future__ import annotations
 
 import json

--- a/generative-ai/text-generation-with-langchain/src/utils.py
+++ b/generative-ai/text-generation-with-langchain/src/utils.py
@@ -14,7 +14,6 @@ from typing import Dict, Any, Optional, Union, List, Tuple
 from IPython.display import HTML, display
 from .trt_llm_langchain import TensorRTLangchain
 
-
 # Default models to be loaded in our examples:
 DEFAULT_MODELS = {
     "local": "/home/jovyan/datafabric/meta-llama3.1-8b-Q8/Meta-Llama-3.1-8B-Instruct-Q8_0.gguf",

--- a/generative-ai/text-summarization-with-langchain/demo/streamlit/main.py
+++ b/generative-ai/text-summarization-with-langchain/demo/streamlit/main.py
@@ -81,12 +81,10 @@ def extract_text_from_file(uploaded_file) -> str:
 
 st.title("📄✨ Text Summarization with AI Studio")
 
-st.markdown(
-    """
+st.markdown("""
 Upload a **document** (TXT, PDF, DOCX) or paste text directly to generate an AI-powered summary.
 Adjust the parameters in the sidebar, then press **Summarize**.
-"""
-)
+""")
 
 # Initialize session state
 if "extracted_text" not in st.session_state:

--- a/generative-ai/text-summarization-with-langchain/src/utils.py
+++ b/generative-ai/text-summarization-with-langchain/src/utils.py
@@ -12,7 +12,6 @@ from pathlib import Path
 from typing import Dict, Any, Optional, Union, List, Tuple
 from .trt_llm_langchain import TensorRTLangchain
 
-
 # Default models to be loaded in our examples:
 DEFAULT_MODELS = {
     "local": "/home/jovyan/datafabric/meta-llama3.1-8b-Q8/Meta-Llama-3.1-8B-Instruct-Q8_0.gguf",

--- a/generative-ai/vanilla-rag-with-langchain/demo/streamlit/main.py
+++ b/generative-ai/vanilla-rag-with-langchain/demo/streamlit/main.py
@@ -19,12 +19,10 @@ st.markdown(
 # ─── Sidebar with Instructions ────────────────────────────────────────────────
 with st.sidebar:
     st.header("📝 Instructions")
-    st.markdown(
-        """
+    st.markdown("""
     1. (Optional) Upload a PDF to enrich the knowledge base.
     2. Type your query and an optional prompt, then Submit.
-    """
-    )
+    """)
 
 # ─── Session State ────────────────────────────────────────────────────────────
 if "history" not in st.session_state:

--- a/generative-ai/vanilla-rag-with-langchain/src/utils.py
+++ b/generative-ai/vanilla-rag-with-langchain/src/utils.py
@@ -12,7 +12,6 @@ from pathlib import Path
 from typing import Dict, Any, Optional, Union, List, Tuple
 from .trt_llm_langchain import TensorRTLangchain
 
-
 # Default models to be loaded in our examples:
 DEFAULT_MODELS = {
     "local": "/home/jovyan/datafabric/meta-llama3.1-8b-Q8/Meta-Llama-3.1-8B-Instruct-Q8_0.gguf",

--- a/ngc-integration/agentic-rag-with-tensorrtllm/demo/streamlit/main.py
+++ b/ngc-integration/agentic-rag-with-tensorrtllm/demo/streamlit/main.py
@@ -5,7 +5,6 @@ import base64
 import json
 from pathlib import Path
 
-
 os.environ.setdefault("NO_PROXY", "localhost,127.0.0.1")
 
 # --- Streamlit Page Configuration ---
@@ -218,15 +217,13 @@ if st.button("🔍 Get Answer"):
             except requests.exceptions.RequestException as e:
                 st.error("❌ Error connecting to the MLflow endpoint.")
                 st.error(f"Details: {str(e)}")
-                st.info(
-                    """
+                st.info("""
                 **Troubleshooting Tips:**
                 - Ensure the MLflow model is deployed and running
                 - Check that the endpoint URL is correct
                 - Verify the model is registered in MLflow
                 - Make sure the service is accessible on port 5002
-                """
-                )
+                """)
             except Exception as e:
                 st.error(f"❌ An unexpected error occurred: {str(e)}")
 

--- a/ngc-integration/audio-translation-with-nemo/demo/streamlit/main.py
+++ b/ngc-integration/audio-translation-with-nemo/demo/streamlit/main.py
@@ -74,22 +74,22 @@ st.markdown(
 # ─── Sidebar Instructions ────────────────────────────────────────────────────
 with st.sidebar:
     st.header("How to Use")
-    st.markdown(
-        """
+    st.markdown("""
     1. The model endpoint is automatically configured for deployment.
 
     2. Type or paste the text to translate.
 
     3. Click **Translate** to see the result.
-    """
-    )
+    """)
 
 # ─── MLflow Endpoint Configuration ───────────────────────────────────────────
 MLFLOW_ENDPOINT = "http://localhost:5002/invocations"
 
 # ─── Text Input ───────────────────────────────────────────────────────────────
 text_to_translate = st.text_area(
-    "✏️ Enter text to translate", height=200, placeholder="Type your source text here..."
+    "✏️ Enter text to translate",
+    height=200,
+    placeholder="Type your source text here...",
 )
 
 # ─── Translate Button ─────────────────────────────────────────────────────────

--- a/ngc-integration/vacation-recommendation-with-bert/demo/streamlit/main.py
+++ b/ngc-integration/vacation-recommendation-with-bert/demo/streamlit/main.py
@@ -58,15 +58,13 @@ st.markdown(
 # ─── Sidebar Instructions ────────────────────────────────────────────────────
 with st.sidebar:
     st.header("How to Use")
-    st.markdown(
-        """
+    st.markdown("""
     1. The model endpoint is automatically configured for deployment.
 
     2. Type or paste the type of vacation you would like to be recommended.
 
     3. Click **Get Recommendations** to see the result.
-    """
-    )
+    """)
 
 # ─── MLflow Endpoint Configuration ───────────────────────────────────────────
 MLFLOW_ENDPOINT = "http://localhost:5002/invocations"

--- a/ngc-integration/vacation-recommendation-with-bert/src/onnx_export.py
+++ b/ngc-integration/vacation-recommendation-with-bert/src/onnx_export.py
@@ -23,7 +23,6 @@ sys.path.append(os.path.abspath(os.path.join(os.getcwd(), "..")))
 
 from src.utils import logger  # Project-specific logging utility
 
-
 """
 ONNX Export Utilities for AI-Blueprints
 

--- a/ngc-integration/vacation-recommendation-with-bert/src/onnx_utils.py
+++ b/ngc-integration/vacation-recommendation-with-bert/src/onnx_utils.py
@@ -18,7 +18,6 @@ sys.path.append(os.path.abspath(os.path.join(os.getcwd(), "..")))
 
 from src.utils import logger  # Project-specific logging utility
 
-
 """
 AI-Blueprints MLflow Utilities with ONNX Integration for In-Memory Models
 

--- a/ngc-integration/vacation-recommendation-with-bert/src/utils.py
+++ b/ngc-integration/vacation-recommendation-with-bert/src/utils.py
@@ -22,7 +22,6 @@ from botocore import UNSIGNED  # Disable request signing
 from botocore.config import Config  # Botocore configuration
 from IPython.display import HTML, display  # Rich HTML display utilities (Jupyter)
 
-
 # Color and emoji mapping per level
 STYLE_MAP = {
     logging.DEBUG: {"bg": "#1e90ff", "fg": "white", "icon": "🔍"},


### PR DESCRIPTION
The root cause on **"Automated Evaluation with Structured Outputs"** blueprint was that `llama_cpp.Llama` holds a direct C++ handle to GPU VRAM. After `run-workflow.ipynb` finished evaluation, the `llm` variable was never deleted, keeping ~8–9 GB of VRAM occupied. When `register-model.ipynb` attempted to reload the same model via `mlflow.pyfunc.load_model()`, there was not enough free VRAM to initialize it.

### Solution

Added `del llm` in `run-workflow.ipynb` immediately after evaluation, before saving results. Deleting the Python variable removes the last reference to the object, triggering the llama_cpp C++ destructor which immediately returns the GPU allocation to the driver.

### Changes

- **`run-workflow.ipynb`** — Added `del llm` with an explanatory comment before `final_df.to_csv()`