### PR TITLE
[Fix] Reverting tranformers version

### DIFF
--- a/generative-ai/fine-tuning-with-orpo/requirements.txt
+++ b/generative-ai/fine-tuning-with-orpo/requirements.txt
@@ -7,7 +7,7 @@ peft==0.15.2
 trl==0.16.1
 bitsandbytes==0.49.2
 deepspeed==0.16.7
-transformers==5.0.0
+transformers==4.53.0
 tf-keras==2.19.0
 tabulate==0.9.0
 pandas


### PR DESCRIPTION
Reverting tranformers to 4.53 due to incompability with tensorflow.