### PR TITLE
[fix] vulnerabilities of imagem generation stableddiffusion

### DIFF
--- a/generative-ai/image-generation-with-stablediffusion/demo/streamlit/pyproject.toml
+++ b/generative-ai/image-generation-with-stablediffusion/demo/streamlit/pyproject.toml
@@ -9,8 +9,9 @@ package-mode = false
 [tool.poetry.dependencies]
 python = ">=3.11"
 streamlit = ">=1.54.0,<2.0.0"
-pillow = ">=11.3.0"
-urllib3 = ">=2.5.0"
+pillow = ">=12.2.0"
+urllib3 = ">=2.7.0"
+GitPython = "3.1.50"
 
 
 [build-system]

--- a/generative-ai/image-generation-with-stablediffusion/requirements.txt
+++ b/generative-ai/image-generation-with-stablediffusion/requirements.txt
@@ -3,7 +3,7 @@ setuptools==80.9.0
 packaging==24.1
 accelerate==1.6.0
 torchvision==0.21.0
-transformers>=4.25.1
+transformers>=5.0.0
 ftfy==6.3.1
 tensorboard==2.19.0
 Jinja2==3.1.6
@@ -12,6 +12,6 @@ huggingface-hub==0.25.1
 pydantic>=2.4.0,<3.0.0
 deepspeed==0.15.1
 tensorflow==2.19.0
-pillow>=8.0.0
+pillow>=12.2.0
 pandas>=1.3.0
-mlflow==3.1.0 #TODO: remove me when you finish
+mlflow==3.12.0


### PR DESCRIPTION
Update following libs, this blueprint is deprecated but we need to end the alerts on it for now: 

- urllib3
- pillow
- GitPython
- transformers
- mlflow

